### PR TITLE
feat: pin signature requestor to Harvest webapp + RequestAnyAccess flow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ harvest-common = { path = "common" }
 freenet-stdlib = { version = "0.6", features = ["contract"] }
 freenet-scaffold = "0.2.2"
 freenet-scaffold-macro = "0.2.2"
-ghostkey-common = "0.2.1"
+ghostkey-common = "0.2.3"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -24,29 +24,88 @@ pub use mailbox::{ConversationId, EncryptedMessage, MailboxParameters, MailboxSt
 pub use reputation::{FeedbackEntry, ReputationParameters, ReputationStateV1};
 pub use store::{StoreParameters, StoreStateV1};
 
-/// Stable contract id of the published Harvest webapp container. Used as
-/// the `expected_requestor` when verifying ghostkey-signed listings and
-/// store info: every signature must have been produced by a delegate
-/// call originating from this webapp, ensuring an app the user has
-/// granted ghostkey access to (Harvest itself or another) cannot mint
-/// signatures that pass Harvest's contract verifiers.
+/// Contract id of the Harvest webapp container that this build targets.
 ///
-/// The id is stable across Harvest releases because the underlying web
-/// container contract WASM rarely changes; releases ship by updating
-/// the container's *state* (the bundled UI bytes), not the container
-/// code. If the container code is ever rebuilt with a different hash,
-/// this constant will need to be updated and old stores re-published.
-pub const HARVEST_WEBAPP_CONTRACT_ID: &str = "6FzSeAUKcqJrveKyU8RJgGKc5jRB1Z2juvxXtwTA4Em9";
+/// Read at compile time from `published-contract/contract-id.txt` so that:
+///
+/// * Production, staging, dev, and forked Harvest builds each pin to
+///   their own deployed id — a fork that publishes under a different
+///   container id verifies its own signatures rather than always
+///   trying to match the upstream Harvest deployment.
+/// * The file `published-contract/contract-id.txt`, written by
+///   `cargo make publish-harvest`, is the single source of truth. The
+///   constant tracks whatever's checked in.
+///
+/// Used as the `expected_requestor` when verifying ghostkey-signed
+/// listings and store info: every signature must have been produced
+/// by a delegate call originating from this webapp, ensuring an app
+/// the user has separately granted ghostkey access to via
+/// `RequestAnyAccess` cannot mint signatures that pass Harvest's
+/// contract verifiers.
+///
+/// **Migration note:** if the webapp container WASM is ever rebuilt
+/// with a different hash (e.g. a stdlib bump), the deployed id changes
+/// and listings/stores published under the old id are orphaned. The
+/// migration path is to add the previous id to
+/// `LEGACY_HARVEST_WEBAPP_CONTRACT_IDS` below so historical signatures
+/// continue to verify, similar to how `legacy_delegates.toml` works
+/// for the delegate WASM.
+pub const HARVEST_WEBAPP_CONTRACT_ID: &str =
+    include_str!("../../published-contract/contract-id.txt").trim_ascii();
+
+/// Webapp container ids that previous Harvest deployments used. New
+/// listings/stores sign under `HARVEST_WEBAPP_CONTRACT_ID`; signatures
+/// that arrive carrying one of these ids verify too, so a container
+/// WASM bump doesn't invalidate every existing signed object on the
+/// network. Empty today; populate when the container WASM hash ever
+/// changes (and bump the canonical id above to the new value).
+pub const LEGACY_HARVEST_WEBAPP_CONTRACT_IDS: &[&str] = &[];
+
+/// Cached parsed `SignatureRequestor` for `HARVEST_WEBAPP_CONTRACT_ID`.
+/// Without this, every signature verification re-parses the constant.
+#[cfg(feature = "ghostkey")]
+static EXPECTED_HARVEST_REQUESTOR: std::sync::LazyLock<ghostkey_common::SignatureRequestor> =
+    std::sync::LazyLock::new(|| {
+        use freenet_stdlib::prelude::ContractInstanceId;
+        let id = ContractInstanceId::from_bytes(HARVEST_WEBAPP_CONTRACT_ID)
+            .expect("HARVEST_WEBAPP_CONTRACT_ID must parse as a valid ContractInstanceId");
+        ghostkey_common::SignatureRequestor::WebApp(id)
+    });
 
 /// Build the runtime-attested `SignatureRequestor` value that signatures
 /// produced for Harvest must carry. Verifiers compare the requestor
 /// embedded in the `ScopedPayload` against this; mismatch is a hard fail.
 #[cfg(feature = "ghostkey")]
 pub fn expected_harvest_requestor() -> ghostkey_common::SignatureRequestor {
-    use freenet_stdlib::prelude::ContractInstanceId;
-    let id = ContractInstanceId::from_bytes(HARVEST_WEBAPP_CONTRACT_ID)
-        .expect("HARVEST_WEBAPP_CONTRACT_ID must parse as a valid ContractInstanceId");
-    ghostkey_common::SignatureRequestor::WebApp(id)
+    (*EXPECTED_HARVEST_REQUESTOR).clone()
+}
+
+/// Test that the canonical webapp id parses cleanly. Surfaces a typo or
+/// stray whitespace in `contract-id.txt` at `cargo test` time rather
+/// than as a panic on first signature verify in WASM.
+#[cfg(test)]
+#[test]
+fn harvest_webapp_contract_id_parses() {
+    let bytes = bs58::decode(HARVEST_WEBAPP_CONTRACT_ID)
+        .into_vec()
+        .expect("HARVEST_WEBAPP_CONTRACT_ID must decode as base58");
+    assert_eq!(
+        bytes.len(),
+        32,
+        "HARVEST_WEBAPP_CONTRACT_ID must decode to 32 bytes; got {}",
+        bytes.len()
+    );
+}
+
+#[cfg(all(test, feature = "ghostkey"))]
+#[test]
+fn expected_harvest_requestor_constructs() {
+    // Ensures the LazyLock initialiser doesn't panic on first access.
+    let r = expected_harvest_requestor();
+    match r {
+        ghostkey_common::SignatureRequestor::WebApp(_) => {}
+        other => panic!("expected WebApp, got {other:?}"),
+    }
 }
 
 /// Serialize a value to CBOR bytes.

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -24,6 +24,31 @@ pub use mailbox::{ConversationId, EncryptedMessage, MailboxParameters, MailboxSt
 pub use reputation::{FeedbackEntry, ReputationParameters, ReputationStateV1};
 pub use store::{StoreParameters, StoreStateV1};
 
+/// Stable contract id of the published Harvest webapp container. Used as
+/// the `expected_requestor` when verifying ghostkey-signed listings and
+/// store info: every signature must have been produced by a delegate
+/// call originating from this webapp, ensuring an app the user has
+/// granted ghostkey access to (Harvest itself or another) cannot mint
+/// signatures that pass Harvest's contract verifiers.
+///
+/// The id is stable across Harvest releases because the underlying web
+/// container contract WASM rarely changes; releases ship by updating
+/// the container's *state* (the bundled UI bytes), not the container
+/// code. If the container code is ever rebuilt with a different hash,
+/// this constant will need to be updated and old stores re-published.
+pub const HARVEST_WEBAPP_CONTRACT_ID: &str = "6FzSeAUKcqJrveKyU8RJgGKc5jRB1Z2juvxXtwTA4Em9";
+
+/// Build the runtime-attested `SignatureRequestor` value that signatures
+/// produced for Harvest must carry. Verifiers compare the requestor
+/// embedded in the `ScopedPayload` against this; mismatch is a hard fail.
+#[cfg(feature = "ghostkey")]
+pub fn expected_harvest_requestor() -> ghostkey_common::SignatureRequestor {
+    use freenet_stdlib::prelude::ContractInstanceId;
+    let id = ContractInstanceId::from_bytes(HARVEST_WEBAPP_CONTRACT_ID)
+        .expect("HARVEST_WEBAPP_CONTRACT_ID must parse as a valid ContractInstanceId");
+    ghostkey_common::SignatureRequestor::WebApp(id)
+}
+
 /// Serialize a value to CBOR bytes.
 pub fn to_cbor<T: serde::Serialize>(value: &T) -> Result<Vec<u8>, String> {
     let mut buf = Vec::new();

--- a/common/src/listing.rs
+++ b/common/src/listing.rs
@@ -96,10 +96,19 @@ impl AuthorizedListing {
 
 /// Verify a ghostkey delegate signature (ScopedPayload format).
 ///
-/// 1. Parse the 64-byte Ed25519 signature
-/// 2. Verify the signature over the scoped_payload bytes
-/// 3. Deserialize the ScopedPayload and verify the inner payload matches
-///    the CBOR encoding of the expected data
+/// 1. Parse the 64-byte Ed25519 signature.
+/// 2. Verify the signature over the scoped_payload bytes.
+/// 3. Deserialize the ScopedPayload, check the inner payload matches the
+///    CBOR encoding of `expected_data`, AND check the embedded
+///    runtime-attested requestor matches the Harvest webapp contract id
+///    (`expected_harvest_requestor()`).
+///
+/// The requestor pin is what stops a third-party app the user has
+/// granted ghostkey access to from minting Harvest-shaped signatures.
+/// The ghostkey delegate binds the runtime-attested
+/// `MessageOrigin::WebApp(contract_id)` into every signature it
+/// produces; an app whose grant came from a different prompt has its
+/// own contract id baked in, so its signatures fail this check.
 pub fn verify_scoped_signature<T: serde::Serialize>(
     scoped_payload: &[u8],
     signature_bytes: &[u8],
@@ -119,9 +128,8 @@ pub fn verify_scoped_signature<T: serde::Serialize>(
         .verify(scoped_payload, &signature)
         .map_err(|e| format!("signature verification failed: {e}"))?;
 
-    // Verify the inner payload matches the expected data.
-    // The scoped_payload is CBOR-encoded ScopedPayload { requestor, payload }.
-    // We need to extract the payload field and compare it.
+    // Verify the inner payload matches the expected data, AND the
+    // embedded requestor is the Harvest webapp.
     #[cfg(feature = "ghostkey")]
     {
         let scoped: ghostkey_common::ScopedPayload = crate::from_cbor(scoped_payload)
@@ -133,9 +141,19 @@ pub fn verify_scoped_signature<T: serde::Serialize>(
         if scoped.payload != expected_bytes {
             return Err("scoped payload content does not match expected data".into());
         }
+
+        let expected_requestor = crate::expected_harvest_requestor();
+        if scoped.requestor != expected_requestor {
+            return Err(format!(
+                "signature requestor pin mismatch: expected Harvest webapp, got {:?}",
+                scoped.requestor
+            ));
+        }
     }
 
-    // Without ghostkey-common, extract the payload from the raw CBOR structure.
+    // Without ghostkey-common, extract the payload AND requestor from
+    // the raw CBOR structure. The contract id is compared as bytes
+    // against `HARVEST_WEBAPP_CONTRACT_ID` decoded from base58.
     #[cfg(not(feature = "ghostkey"))]
     {
         let value: ciborium::Value = crate::from_cbor(scoped_payload)
@@ -149,6 +167,15 @@ pub fn verify_scoped_signature<T: serde::Serialize>(
 
         if payload_bytes != expected_bytes {
             return Err("scoped payload content does not match expected data".into());
+        }
+
+        let requestor_bytes = extract_webapp_requestor_bytes_from_cbor(&value)
+            .ok_or("scoped payload requestor is not WebApp(_) -- mismatched delegate version?")?;
+        let expected_id_bytes = bs58::decode(crate::HARVEST_WEBAPP_CONTRACT_ID)
+            .into_vec()
+            .map_err(|e| format!("HARVEST_WEBAPP_CONTRACT_ID decode: {e}"))?;
+        if requestor_bytes != expected_id_bytes {
+            return Err("signature requestor pin mismatch: expected Harvest webapp".into());
         }
     }
 
@@ -171,6 +198,31 @@ fn extract_payload_from_cbor(value: &ciborium::Value) -> Option<Vec<u8>> {
     None
 }
 
+/// Extract the contract id bytes of a `WebApp(_)` requestor from a CBOR-
+/// encoded ScopedPayload. Returns `None` for any other requestor variant
+/// (e.g. `Delegate(_)`), which Harvest's verifier should reject.
+#[cfg(not(feature = "ghostkey"))]
+fn extract_webapp_requestor_bytes_from_cbor(value: &ciborium::Value) -> Option<Vec<u8>> {
+    let outer = value.as_map()?;
+    // `requestor` field on the outer ScopedPayload struct.
+    let requestor = outer
+        .iter()
+        .find(|(k, _)| k.as_text() == Some("requestor"))
+        .map(|(_, v)| v)?;
+    // serde-default externally-tagged enum: `{ "WebApp": <ContractInstanceId> }`.
+    let requestor_map = requestor.as_map()?;
+    let (variant, payload) = requestor_map.first()?;
+    if variant.as_text() != Some("WebApp") {
+        return None;
+    }
+    // ContractInstanceId is `[u8; 32]` with `serde_as`, which encodes as
+    // a CBOR array of 32 unsigned-int values. Walk and collect.
+    let arr = payload.as_array()?;
+    arr.iter()
+        .map(|v| v.as_integer().and_then(|i| u8::try_from(i).ok()))
+        .collect::<Option<Vec<u8>>>()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -178,9 +230,15 @@ mod tests {
 
     /// Helper to create a signed listing for testing.
     ///
-    /// Constructs the ScopedPayload manually via CBOR to avoid cross-version
-    /// ContractInstanceId issues (ghostkey-common uses stdlib 0.3.5, we use 0.6).
-    fn make_authorized_listing(signing_key: &SigningKey) -> AuthorizedListing {
+    /// Constructs the ScopedPayload manually via CBOR (avoiding the
+    /// `freenet-stdlib` `ContractInstanceId` constructor) so the test
+    /// can inject any `WebApp(id)` bytes — including the
+    /// `HARVEST_WEBAPP_CONTRACT_ID` the verifier now requires, and an
+    /// arbitrary mismatched id for the negative test.
+    fn make_authorized_listing_with_requestor(
+        signing_key: &SigningKey,
+        requestor_id: [u8; 32],
+    ) -> AuthorizedListing {
         let ts = DateTime::from_timestamp(1700000000, 0).unwrap();
         let listing = Listing {
             id: ListingId::new("abc123", &ts, "Widget"),
@@ -194,9 +252,6 @@ mod tests {
             created_at: ts,
         };
 
-        // Build a ScopedPayload-shaped struct manually to avoid the
-        // cross-stdlib-version ContractInstanceId mismatch.
-        // In production, the ghostkey delegate constructs this.
         #[derive(serde::Serialize)]
         struct TestScopedPayload {
             requestor: TestRequestor,
@@ -209,7 +264,7 @@ mod tests {
 
         let listing_bytes = crate::to_cbor(&listing).unwrap();
         let scoped = TestScopedPayload {
-            requestor: TestRequestor::WebApp([0u8; 32]),
+            requestor: TestRequestor::WebApp(requestor_id),
             payload: listing_bytes,
         };
         let scoped_bytes = crate::to_cbor(&scoped).unwrap();
@@ -221,6 +276,21 @@ mod tests {
             signature: signature.to_bytes().to_vec(),
             certificate_pem: "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----".into(),
         }
+    }
+
+    /// Returns the 32-byte contract id that signatures must carry to
+    /// verify under Harvest's pinned requestor.
+    fn harvest_requestor_bytes() -> [u8; 32] {
+        let v = bs58::decode(crate::HARVEST_WEBAPP_CONTRACT_ID)
+            .into_vec()
+            .expect("HARVEST_WEBAPP_CONTRACT_ID must decode as base58");
+        let mut a = [0u8; 32];
+        a.copy_from_slice(&v);
+        a
+    }
+
+    fn make_authorized_listing(signing_key: &SigningKey) -> AuthorizedListing {
+        make_authorized_listing_with_requestor(signing_key, harvest_requestor_bytes())
     }
 
     #[test]
@@ -266,5 +336,35 @@ mod tests {
         // Tamper with the listing title after signing
         authorized.listing.title = "Tampered".into();
         assert!(authorized.verify(&verifying_key).is_err());
+    }
+
+    /// Regression test: a signature whose runtime-attested requestor is
+    /// some other webapp must NOT verify, even though the signature
+    /// itself is mathematically valid and the payload matches. This is
+    /// the "Sign grant on a shared key shouldn't impersonate Harvest"
+    /// invariant — the ghostkey delegate binds the calling app's
+    /// contract id into every signature, and Harvest's verifier pins
+    /// that id to the published webapp's id.
+    #[test]
+    fn test_authorized_listing_wrong_requestor_fails() {
+        let signing_key = SigningKey::from_bytes(&[42u8; 32]);
+        let verifying_key = signing_key.verifying_key();
+
+        // Same valid signature, same payload, but signed under a
+        // hostile webapp's contract id.
+        let mut hostile_id = harvest_requestor_bytes();
+        hostile_id[0] ^= 0xff;
+        let authorized = make_authorized_listing_with_requestor(&signing_key, hostile_id);
+
+        let result = authorized.verify(&verifying_key);
+        assert!(
+            result.is_err(),
+            "verifier must reject signatures whose requestor isn't the Harvest webapp; got {result:?}"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("requestor"),
+            "error must mention the requestor pin; got: {err}"
+        );
     }
 }

--- a/common/src/listing.rs
+++ b/common/src/listing.rs
@@ -101,14 +101,28 @@ impl AuthorizedListing {
 /// 3. Deserialize the ScopedPayload, check the inner payload matches the
 ///    CBOR encoding of `expected_data`, AND check the embedded
 ///    runtime-attested requestor matches the Harvest webapp contract id
-///    (`expected_harvest_requestor()`).
+///    (canonical or any legacy id).
 ///
-/// The requestor pin is what stops a third-party app the user has
-/// granted ghostkey access to from minting Harvest-shaped signatures.
-/// The ghostkey delegate binds the runtime-attested
-/// `MessageOrigin::WebApp(contract_id)` into every signature it
-/// produces; an app whose grant came from a different prompt has its
-/// own contract id baked in, so its signatures fail this check.
+/// ## What the requestor pin does
+///
+/// It stops a third-party webapp that the user has granted ghostkey
+/// access to **via `RequestAnyAccess`** from minting Harvest-shaped
+/// signatures: the ghostkey delegate binds the calling app's
+/// runtime-attested `MessageOrigin::WebApp(contract_id)` into every
+/// signature it produces, and Harvest rejects signatures whose
+/// embedded id isn't ours.
+///
+/// ## What the requestor pin does NOT do
+///
+/// It does NOT stop an attacker who has obtained the seller's
+/// **private signing key** directly (e.g. via PEM exfiltration,
+/// backup leak, or a permissioned delegate that grants
+/// `GhostkeyScope::Export` to a hostile app). Such an attacker can
+/// fabricate a `ScopedPayload { requestor: WebApp(HARVEST_ID), ... }`
+/// offline and sign it with the seller's key; nothing in the
+/// signature itself is runtime-attested. The pin is a defence
+/// against delegate-mediated cross-app misuse, not a defence against
+/// PEM theft.
 pub fn verify_scoped_signature<T: serde::Serialize>(
     scoped_payload: &[u8],
     signature_bytes: &[u8],
@@ -129,7 +143,8 @@ pub fn verify_scoped_signature<T: serde::Serialize>(
         .map_err(|e| format!("signature verification failed: {e}"))?;
 
     // Verify the inner payload matches the expected data, AND the
-    // embedded requestor is the Harvest webapp.
+    // embedded requestor is one of the accepted Harvest webapp ids
+    // (canonical or legacy).
     #[cfg(feature = "ghostkey")]
     {
         let scoped: ghostkey_common::ScopedPayload = crate::from_cbor(scoped_payload)
@@ -142,18 +157,30 @@ pub fn verify_scoped_signature<T: serde::Serialize>(
             return Err("scoped payload content does not match expected data".into());
         }
 
-        let expected_requestor = crate::expected_harvest_requestor();
-        if scoped.requestor != expected_requestor {
+        // Reject non-WebApp requestors outright (delegate-to-delegate
+        // calls cannot have produced this signature).
+        let signer_id = match &scoped.requestor {
+            ghostkey_common::SignatureRequestor::WebApp(id) => id,
+            other => {
+                return Err(format!(
+                    "signature requestor pin mismatch: expected Harvest webapp, got {other:?}"
+                ));
+            }
+        };
+
+        let signer_id_str = signer_id.to_string();
+        if signer_id_str != crate::HARVEST_WEBAPP_CONTRACT_ID
+            && !crate::LEGACY_HARVEST_WEBAPP_CONTRACT_IDS.contains(&signer_id_str.as_str())
+        {
             return Err(format!(
-                "signature requestor pin mismatch: expected Harvest webapp, got {:?}",
-                scoped.requestor
+                "signature requestor pin mismatch: expected Harvest webapp, got {signer_id_str}"
             ));
         }
     }
 
     // Without ghostkey-common, extract the payload AND requestor from
     // the raw CBOR structure. The contract id is compared as bytes
-    // against `HARVEST_WEBAPP_CONTRACT_ID` decoded from base58.
+    // against the canonical id and any legacy ids.
     #[cfg(not(feature = "ghostkey"))]
     {
         let value: ciborium::Value = crate::from_cbor(scoped_payload)
@@ -170,11 +197,23 @@ pub fn verify_scoped_signature<T: serde::Serialize>(
         }
 
         let requestor_bytes = extract_webapp_requestor_bytes_from_cbor(&value)
-            .ok_or("scoped payload requestor is not WebApp(_) -- mismatched delegate version?")?;
-        let expected_id_bytes = bs58::decode(crate::HARVEST_WEBAPP_CONTRACT_ID)
+            .ok_or("scoped payload requestor is not WebApp(_); rejecting")?;
+
+        let canonical_id_bytes = bs58::decode(crate::HARVEST_WEBAPP_CONTRACT_ID)
             .into_vec()
             .map_err(|e| format!("HARVEST_WEBAPP_CONTRACT_ID decode: {e}"))?;
-        if requestor_bytes != expected_id_bytes {
+        let mut accepted = requestor_bytes == canonical_id_bytes;
+        if !accepted {
+            for legacy in crate::LEGACY_HARVEST_WEBAPP_CONTRACT_IDS {
+                if let Ok(legacy_bytes) = bs58::decode(legacy).into_vec() {
+                    if requestor_bytes == legacy_bytes {
+                        accepted = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if !accepted {
             return Err("signature requestor pin mismatch: expected Harvest webapp".into());
         }
     }
@@ -185,14 +224,27 @@ pub fn verify_scoped_signature<T: serde::Serialize>(
 /// Extract the "payload" field from a CBOR-encoded ScopedPayload.
 /// ScopedPayload is a struct with `requestor` and `payload` fields,
 /// serialized as a CBOR map.
+///
+/// `Vec<u8>` via `serde::Serialize`'s default impl encodes as a CBOR
+/// array of unsigned integers, not as a byte string. Accept both
+/// shapes so a future switch to `#[serde(with = "serde_bytes")]` (or
+/// any consumer that uses byte-string encoding) doesn't silently
+/// break verification.
 #[cfg(not(feature = "ghostkey"))]
 fn extract_payload_from_cbor(value: &ciborium::Value) -> Option<Vec<u8>> {
     let map = value.as_map()?;
     for (key, val) in map {
-        if let Some(key_str) = key.as_text() {
-            if key_str == "payload" {
-                return val.as_bytes().map(|b| b.to_vec());
+        if key.as_text() == Some("payload") {
+            if let Some(bytes) = val.as_bytes() {
+                return Some(bytes.to_vec());
             }
+            if let Some(arr) = val.as_array() {
+                return arr
+                    .iter()
+                    .map(|v| v.as_integer().and_then(|i| u8::try_from(i).ok()))
+                    .collect::<Option<Vec<u8>>>();
+            }
+            return None;
         }
     }
     None
@@ -366,5 +418,170 @@ mod tests {
             err.contains("requestor"),
             "error must mention the requestor pin; got: {err}"
         );
+    }
+
+    /// Regression test: a `ScopedPayload` whose requestor is a `Delegate(_)`
+    /// (rather than `WebApp(_)`) must be rejected. The verifier helper for
+    /// the no-feature CBOR path explicitly returns None for non-WebApp
+    /// variants; the feature-on path matches on `WebApp` and rejects
+    /// otherwise. Without this test, a future delegate-to-delegate
+    /// signing path could produce signatures the verifier silently
+    /// accepted (depending on how the CBOR walker fell through).
+    #[test]
+    fn test_authorized_listing_delegate_requestor_fails() {
+        let signing_key = SigningKey::from_bytes(&[42u8; 32]);
+        let verifying_key = signing_key.verifying_key();
+        let ts = DateTime::from_timestamp(1700000000, 0).unwrap();
+        let listing = Listing {
+            id: ListingId::new("abc123", &ts, "Widget"),
+            title: "Widget".into(),
+            description: "n/a".into(),
+            kind: ListingKind::Sale,
+            price: None,
+            created_at: ts,
+        };
+
+        // Build a ScopedPayload whose requestor is the `Delegate(_)`
+        // variant. Externally tagged: `{ "Delegate": <delegate_key_bytes> }`.
+        #[derive(serde::Serialize)]
+        struct TestScopedPayload {
+            requestor: TestRequestor,
+            payload: Vec<u8>,
+        }
+        #[derive(serde::Serialize)]
+        enum TestRequestor {
+            #[allow(dead_code)] // keep variant for completeness
+            WebApp([u8; 32]),
+            Delegate(Vec<u8>),
+        }
+        let listing_bytes = crate::to_cbor(&listing).unwrap();
+        let scoped = TestScopedPayload {
+            requestor: TestRequestor::Delegate(vec![1u8; 32]),
+            payload: listing_bytes,
+        };
+        let scoped_bytes = crate::to_cbor(&scoped).unwrap();
+        let signature = signing_key.sign(&scoped_bytes);
+        let authorized = AuthorizedListing {
+            listing,
+            scoped_payload: scoped_bytes,
+            signature: signature.to_bytes().to_vec(),
+            certificate_pem: "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----".into(),
+        };
+
+        let result = authorized.verify(&verifying_key);
+        assert!(
+            result.is_err(),
+            "delegate requestor must be rejected; got {result:?}"
+        );
+    }
+
+    /// Regression test for the store-info verifier path. `store.rs`
+    /// calls `verify_scoped_signature` from both `verify` and
+    /// `apply_delta`; the requestor pin applies to those call sites
+    /// too. Tests there were previously absent.
+    #[test]
+    fn test_authorized_store_info_wrong_requestor_fails() {
+        use crate::store::{AuthorizedStoreInfoV1, StoreInfoV1, StoreParameters, StoreStateV1};
+
+        let signing_key = SigningKey::from_bytes(&[55u8; 32]);
+        let verifying_key = signing_key.verifying_key();
+
+        let info = StoreInfoV1 {
+            version: 1,
+            certificate_pem: "test-cert".into(),
+            seller_fingerprint: "fp".into(),
+            reputation_contract_id: [0u8; 32],
+            store_name: "TestStore".into(),
+            description: "".into(),
+            payment_instructions: "".into(),
+        };
+        let info_bytes = crate::to_cbor(&info).unwrap();
+
+        // Sign with a hostile requestor id (NOT the harvest webapp).
+        #[derive(serde::Serialize)]
+        struct TestScopedPayload {
+            requestor: TestRequestor,
+            payload: Vec<u8>,
+        }
+        #[derive(serde::Serialize)]
+        enum TestRequestor {
+            WebApp([u8; 32]),
+        }
+        let mut hostile_id = harvest_requestor_bytes();
+        hostile_id[0] ^= 0xff;
+        let scoped = TestScopedPayload {
+            requestor: TestRequestor::WebApp(hostile_id),
+            payload: info_bytes,
+        };
+        let scoped_bytes = crate::to_cbor(&scoped).unwrap();
+        let signature = signing_key.sign(&scoped_bytes);
+
+        let authorized = AuthorizedStoreInfoV1 {
+            info,
+            scoped_payload: scoped_bytes,
+            signature: signature.to_bytes().to_vec(),
+        };
+        let parent = StoreStateV1::default();
+        let params = StoreParameters {
+            seller_verifying_key: verifying_key,
+        };
+
+        use freenet_scaffold::ComposableState;
+        let result = authorized.verify(&parent, &params);
+        assert!(
+            result.is_err(),
+            "store-info verifier must reject hostile-requestor signatures; got {result:?}"
+        );
+    }
+
+    /// Happy-path: an `AuthorizedStoreInfoV1` signed under the canonical
+    /// Harvest requestor verifies cleanly through the same composable
+    /// `verify` entry point used by the store contract.
+    #[test]
+    fn test_authorized_store_info_verifies() {
+        use crate::store::{AuthorizedStoreInfoV1, StoreInfoV1, StoreParameters, StoreStateV1};
+
+        let signing_key = SigningKey::from_bytes(&[55u8; 32]);
+        let verifying_key = signing_key.verifying_key();
+
+        let info = StoreInfoV1 {
+            version: 1,
+            certificate_pem: "test-cert".into(),
+            seller_fingerprint: "fp".into(),
+            reputation_contract_id: [0u8; 32],
+            store_name: "TestStore".into(),
+            description: "".into(),
+            payment_instructions: "".into(),
+        };
+        let info_bytes = crate::to_cbor(&info).unwrap();
+
+        #[derive(serde::Serialize)]
+        struct TestScopedPayload {
+            requestor: TestRequestor,
+            payload: Vec<u8>,
+        }
+        #[derive(serde::Serialize)]
+        enum TestRequestor {
+            WebApp([u8; 32]),
+        }
+        let scoped = TestScopedPayload {
+            requestor: TestRequestor::WebApp(harvest_requestor_bytes()),
+            payload: info_bytes,
+        };
+        let scoped_bytes = crate::to_cbor(&scoped).unwrap();
+        let signature = signing_key.sign(&scoped_bytes);
+
+        let authorized = AuthorizedStoreInfoV1 {
+            info,
+            scoped_payload: scoped_bytes,
+            signature: signature.to_bytes().to_vec(),
+        };
+        let parent = StoreStateV1::default();
+        let params = StoreParameters {
+            seller_verifying_key: verifying_key,
+        };
+
+        use freenet_scaffold::ComposableState;
+        assert!(authorized.verify(&parent, &params).is_ok());
     }
 }

--- a/published-contract/contract-id.txt
+++ b/published-contract/contract-id.txt
@@ -1,0 +1,1 @@
+6FzSeAUKcqJrveKyU8RJgGKc5jRB1Z2juvxXtwTA4Em9

--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -48,25 +48,20 @@ pub fn App() -> Element {
                     }
                 }
 
-                // Step 3: Register the ghostkey delegate
+                // Step 3: Register the ghostkey delegate. We deliberately
+                // do NOT call `ListGhostKeys` on startup any more: the
+                // vault now auto-grants only the importing webapp (the
+                // Ghostkey Vault itself) on key import, so for any other
+                // webapp `ListGhostKeys` returns an empty list until the
+                // user explicitly approves a `RequestAnyAccess` prompt.
+                // The "Connect a ghostkey" button on the My Store empty
+                // state triggers that prompt; the response folds the
+                // shared key into APP_STATE.ghostkeys.
                 let gk_wasm = include_bytes!("../../public/contracts/ghostkey_delegate.wasm");
                 match crate::gateway::register_delegate(gk_wasm).await {
                     Ok(key) => {
                         dioxus::logger::tracing::info!("Ghostkey delegate registered: {:?}", key);
-                        crate::gateway::APP_STATE.write().ghostkey_delegate_key = Some(key.clone());
-
-                        // Request the list of ghostkeys
-                        let list_request = ghostkey_common::GhostkeyRequest::ListGhostKeys;
-                        if let Ok(payload) = ghostkey_common::to_cbor(&list_request) {
-                            if let Err(e) =
-                                crate::gateway::send_delegate_message(&key, payload).await
-                            {
-                                dioxus::logger::tracing::error!(
-                                    "Failed to request ghostkey list: {}",
-                                    e
-                                );
-                            }
-                        }
+                        crate::gateway::APP_STATE.write().ghostkey_delegate_key = Some(key);
                     }
                     Err(e) => {
                         dioxus::logger::tracing::error!(

--- a/ui/src/components/my_store.rs
+++ b/ui/src/components/my_store.rs
@@ -30,13 +30,54 @@ pub fn MyStore() -> Element {
 fn NoIdentity() -> Element {
     rsx! {
         div { class: "card empty-state",
-            p { "No ghostkey identities found." }
             p {
-                "To create a store, you need a ghostkey identity. Visit the "
-                "Ghostkey Manager to import or create one via a Freenet donation."
+                "Harvest needs a ghostkey identity to sign your store listings."
+            }
+            p {
+                "If you've already created one, share it with Harvest below. "
+                "Otherwise, visit the Ghostkey Vault to create one."
+            }
+            div { style: "margin-top: 16px;",
+                button {
+                    class: "btn btn-primary",
+                    onclick: move |_| connect_ghostkey(),
+                    "Connect a ghostkey"
+                }
             }
         }
     }
+}
+
+/// Send a `RequestAnyAccess` request to the ghostkey delegate. The
+/// delegate emits a `RequestUserInput` that the gateway shell-page
+/// renders as an overlay; the user picks one of their stored
+/// ghostkeys (or denies). On approval the delegate replies with a
+/// one-element `GhostKeyList` for the chosen key, which the response
+/// handler folds into APP_STATE.ghostkeys -- our `IdentityList`
+/// renders as soon as it appears.
+fn connect_ghostkey() {
+    use ghostkey_common::GhostkeyRequest;
+    let key = match APP_STATE.read().ghostkey_delegate_key.clone() {
+        Some(k) => k,
+        None => {
+            dioxus::logger::tracing::warn!(
+                "Ghostkey delegate not yet registered; cannot request access"
+            );
+            return;
+        }
+    };
+    spawn(async move {
+        let payload = match ghostkey_common::to_cbor(&GhostkeyRequest::RequestAnyAccess) {
+            Ok(p) => p,
+            Err(e) => {
+                dioxus::logger::tracing::error!("Failed to encode RequestAnyAccess: {e}");
+                return;
+            }
+        };
+        if let Err(e) = crate::gateway::send_delegate_message(&key, payload).await {
+            dioxus::logger::tracing::error!("Failed to send RequestAnyAccess: {e}");
+        }
+    });
 }
 
 #[component]

--- a/ui/src/components/my_store.rs
+++ b/ui/src/components/my_store.rs
@@ -7,13 +7,14 @@ use crate::gateway::APP_STATE;
 #[component]
 pub fn MyStore() -> Element {
     let app_state = APP_STATE.read();
+    let in_flight = app_state.request_any_access_in_flight;
 
     rsx! {
         div {
             h2 { "My Store" }
 
             if app_state.ghostkeys.is_empty() {
-                NoIdentity {}
+                NoIdentity { in_flight: in_flight }
             } else {
                 IdentityList {
                     ghostkeys: app_state.ghostkeys.clone(),
@@ -21,13 +22,14 @@ pub fn MyStore() -> Element {
                     rsa_keys: app_state.rsa_public_keys.clone(),
                     has_harvest_delegate: app_state.harvest_delegate_key.is_some(),
                 }
+                ConnectAnother { in_flight: in_flight }
             }
         }
     }
 }
 
 #[component]
-fn NoIdentity() -> Element {
+fn NoIdentity(in_flight: bool) -> Element {
     rsx! {
         div { class: "card empty-state",
             p {
@@ -40,9 +42,28 @@ fn NoIdentity() -> Element {
             div { style: "margin-top: 16px;",
                 button {
                     class: "btn btn-primary",
+                    disabled: in_flight,
                     onclick: move |_| connect_ghostkey(),
-                    "Connect a ghostkey"
+                    if in_flight { "Waiting for vault…" } else { "Connect a ghostkey" }
                 }
+            }
+        }
+    }
+}
+
+/// Lets a user with one or more already-connected ghostkeys request
+/// access to ANOTHER one. Without this, the empty-state's "Connect"
+/// button disappears after the first successful share and there's no
+/// path to add a second identity.
+#[component]
+fn ConnectAnother(in_flight: bool) -> Element {
+    rsx! {
+        div { style: "margin-top: 16px;",
+            button {
+                class: "btn",
+                disabled: in_flight,
+                onclick: move |_| connect_ghostkey(),
+                if in_flight { "Waiting for vault…" } else { "Connect another ghostkey" }
             }
         }
     }
@@ -57,25 +78,47 @@ fn NoIdentity() -> Element {
 /// renders as soon as it appears.
 fn connect_ghostkey() {
     use ghostkey_common::GhostkeyRequest;
-    let key = match APP_STATE.read().ghostkey_delegate_key.clone() {
-        Some(k) => k,
-        None => {
-            dioxus::logger::tracing::warn!(
-                "Ghostkey delegate not yet registered; cannot request access"
+
+    // Snapshot delegate key + check the in-flight flag in a single
+    // borrow. If we're already mid-request, drop the click so rapid
+    // double-clicks don't queue duplicate prompts (and overwrite each
+    // other's GhostKeyList responses on completion).
+    let key = {
+        let state = APP_STATE.read();
+        if state.request_any_access_in_flight {
+            dioxus::logger::tracing::info!(
+                "RequestAnyAccess already in flight; ignoring duplicate click"
             );
             return;
         }
+        match state.ghostkey_delegate_key.clone() {
+            Some(k) => k,
+            None => {
+                dioxus::logger::tracing::warn!(
+                    "Ghostkey delegate not yet registered; cannot request access"
+                );
+                APP_STATE
+                    .write()
+                    .notifications
+                    .push("Still connecting to the gateway — please try again in a moment.".into());
+                return;
+            }
+        }
     };
+
+    APP_STATE.write().request_any_access_in_flight = true;
     spawn(async move {
         let payload = match ghostkey_common::to_cbor(&GhostkeyRequest::RequestAnyAccess) {
             Ok(p) => p,
             Err(e) => {
                 dioxus::logger::tracing::error!("Failed to encode RequestAnyAccess: {e}");
+                APP_STATE.write().request_any_access_in_flight = false;
                 return;
             }
         };
         if let Err(e) = crate::gateway::send_delegate_message(&key, payload).await {
             dioxus::logger::tracing::error!("Failed to send RequestAnyAccess: {e}");
+            APP_STATE.write().request_any_access_in_flight = false;
         }
     });
 }

--- a/ui/src/state.rs
+++ b/ui/src/state.rs
@@ -33,8 +33,17 @@ pub struct AppState {
     /// Our own stores (ghostkey fingerprint -> list of registrations).
     pub my_stores: HashMap<String, Vec<StoreRegistration>>,
 
-    /// Ghostkey identities available to us.
+    /// Ghostkey identities available to us. Each successful
+    /// `RequestAnyAccess` response merges (deduped by fingerprint) into
+    /// this list rather than replacing it, so users can connect a
+    /// second key without losing visibility into the first.
     pub ghostkeys: Vec<ghostkey_common::GhostKeyInfo>,
+
+    /// Set while a `RequestAnyAccess` is in flight, so the UI can
+    /// disable the "Connect" button and rapid double-clicks don't queue
+    /// multiple delegate prompts. Cleared on every terminal response
+    /// (GhostKeyList success, AccessDenied, NoIdentityAvailable, Error).
+    pub request_any_access_in_flight: bool,
 
     /// RSA public keys for our identities (fingerprint -> DER bytes).
     pub rsa_public_keys: HashMap<String, Vec<u8>>,
@@ -282,7 +291,23 @@ impl AppState {
                         }
                     }
                 }
-                self.ghostkeys = keys;
+                // Merge new keys into the existing list (dedup by
+                // fingerprint, prefer the newer entry). Wholesale
+                // replacement would drop previously-connected keys
+                // when a second `RequestAnyAccess` returns a single
+                // newly-shared key.
+                for key in keys {
+                    if let Some(slot) = self
+                        .ghostkeys
+                        .iter_mut()
+                        .find(|k| k.fingerprint == key.fingerprint)
+                    {
+                        *slot = key;
+                    } else {
+                        self.ghostkeys.push(key);
+                    }
+                }
+                self.request_any_access_in_flight = false;
             }
 
             ghostkey_common::GhostkeyResponse::SignResult {
@@ -362,28 +387,55 @@ impl AppState {
                 self.notifications
                     .push(format!("Ghostkey error: {message}"));
                 self.pending_listing = None;
+                self.request_any_access_in_flight = false;
             }
 
             // The user denied a `RequestAnyAccess` prompt. Surface a
-            // clear notification so the empty-state isn't silently
-            // stuck after the prompt closed; without this branch the
-            // `_ => Unhandled` fallthrough below would just log.
+            // notification, clear the in-flight flag so the button is
+            // enabled again, and clear any pending listing/store
+            // creation that was waiting on this grant. Without this
+            // cleanup, a subsequent successful SignResult would
+            // consume the stale pending listing.
             ghostkey_common::GhostkeyResponse::AccessDenied { .. } => {
                 self.notifications.push(
                     "Ghostkey access was denied. Click 'Connect a ghostkey' again to retry.".into(),
                 );
+                self.request_any_access_in_flight = false;
+                self.pending_listing = None;
+                self.pending_store_creation = None;
             }
 
-            // The vault has no ghostkeys at all. Tell the user where to
-            // go to create one.
+            // The vault has no ghostkeys at all. Tell the user where
+            // to go to create one. Same cleanup as AccessDenied.
             ghostkey_common::GhostkeyResponse::NoIdentityAvailable => {
                 self.notifications.push(
                     "No ghostkey identities found. Open the Ghostkey Vault to create one, then come back and click 'Connect a ghostkey'.".into(),
                 );
+                self.request_any_access_in_flight = false;
+                self.pending_listing = None;
+                self.pending_store_creation = None;
             }
 
-            // Catch-all for response variants Harvest doesn't act on
-            // (PermissionGranted / PermissionRevoked / etc -- vault-only).
+            // Per-fingerprint denial: the user denied a specific-key
+            // prompt, or the vault revoked the grant between connect
+            // and sign. Same cleanup as the access-denial arms.
+            ghostkey_common::GhostkeyResponse::PermissionDenied { fingerprint, .. } => {
+                self.notifications
+                    .push(format!("Ghostkey access denied for {fingerprint}."));
+                self.request_any_access_in_flight = false;
+                self.pending_listing = None;
+                self.pending_store_creation = None;
+            }
+
+            // Vault-only responses Harvest doesn't act on. The
+            // explicit arms above cover every user-visible failure
+            // mode in the current ghostkey-common protocol; this
+            // wildcard is just for vault-management responses
+            // (PermissionGranted / PermissionRevoked / PermissionList /
+            // KeyNotFound / VerifyResult / Deleted / LabelSet, etc).
+            // A future response variant with a failure semantic
+            // would slip through here -- worth re-auditing on every
+            // ghostkey-common bump.
             #[allow(clippy::wildcard_enum_match_arm)]
             _ => {
                 info!("Unhandled ghostkey response: {:?}", response);

--- a/ui/src/state.rs
+++ b/ui/src/state.rs
@@ -364,6 +364,27 @@ impl AppState {
                 self.pending_listing = None;
             }
 
+            // The user denied a `RequestAnyAccess` prompt. Surface a
+            // clear notification so the empty-state isn't silently
+            // stuck after the prompt closed; without this branch the
+            // `_ => Unhandled` fallthrough below would just log.
+            ghostkey_common::GhostkeyResponse::AccessDenied { .. } => {
+                self.notifications.push(
+                    "Ghostkey access was denied. Click 'Connect a ghostkey' again to retry.".into(),
+                );
+            }
+
+            // The vault has no ghostkeys at all. Tell the user where to
+            // go to create one.
+            ghostkey_common::GhostkeyResponse::NoIdentityAvailable => {
+                self.notifications.push(
+                    "No ghostkey identities found. Open the Ghostkey Vault to create one, then come back and click 'Connect a ghostkey'.".into(),
+                );
+            }
+
+            // Catch-all for response variants Harvest doesn't act on
+            // (PermissionGranted / PermissionRevoked / etc -- vault-only).
+            #[allow(clippy::wildcard_enum_match_arm)]
             _ => {
                 info!("Unhandled ghostkey response: {:?}", response);
             }


### PR DESCRIPTION
## Problem

Harvest's "My Store" empty state shows "No ghostkey identities found" because the ghostkey delegate's `ListGhostKeys` filters per-requestor and Harvest has no grant — chicken-and-egg, since discovery is what `ListGhostKeys` is supposed to provide. Resolved upstream by `freenet/ghostkeys#7`, which adds a `RequestAnyAccess` flow: the user picks one of their ghostkeys to share with the requesting app and the delegate auto-grants `{ReadPublic, Sign}` for it.

But there's a second concern: once a user has shared a key with multiple apps, what stops App B from minting signatures that look like App A's? The ghostkey delegate already binds the runtime-attested calling contract id into every signature it produces (`ScopedPayload.requestor`), but Harvest's verifier wasn't checking it. So a `Sign` grant for the same key shared with two different apps could let either one impersonate the other.

## Solution

Two coordinated changes against `ghostkey-common 0.2.3`:

### 1. Verifier-side requestor pin

`HARVEST_WEBAPP_CONTRACT_ID = "6FzSeAUKcqJrveKyU8RJgGKc5jRB1Z2juvxXtwTA4Em9"` is exported from `harvest-common`. `verify_scoped_signature` extracts the requestor embedded in the `ScopedPayload` and hard-fails if it isn't the Harvest webapp. The webapp container contract id is stable across Harvest releases (releases update state, not container code) so the pin doesn't impose a migration burden.

Both feature branches updated:
- `cfg(feature = "ghostkey")` deserialises directly via `ghostkey_common::ScopedPayload` and compares to `expected_harvest_requestor()`.
- `cfg(not(feature = "ghostkey"))` walks raw CBOR (`extract_webapp_requestor_bytes_from_cbor`) and compares against the base58-decoded `HARVEST_WEBAPP_CONTRACT_ID` bytes.

### 2. `RequestAnyAccess` UI flow

The auto-`ListGhostKeys` on connect is removed — wasted work now that the delegate gates list results behind a grant. The empty state shows a "Connect a ghostkey" button that fires `RequestAnyAccess`; the gateway shell-page renders the delegate's prompt; on approval the response handler folds the returned one-element `GhostKeyList` into `APP_STATE.ghostkeys` and `IdentityList` renders.

`AccessDenied` and `NoIdentityAvailable` get explicit response-handler arms with user-facing notifications so the empty state isn't silently stuck after a deny or a vault that lacks any keys.

## Testing

- **`test_authorized_listing_wrong_requestor_fails`** (new regression): a signature whose requestor is some other webapp must NOT verify, even though the signature is valid and the payload matches. Pins the "Sign grant on a shared key shouldn't impersonate Harvest" invariant.
- Existing tests (`test_authorized_listing_verify`, `test_authorized_listing_wrong_key_fails`, `test_authorized_listing_tampered_payload_fails`) updated to use the Harvest webapp id as the requestor.
- `cargo test --workspace --exclude harvest-ui` clean (13/13 pass).
- `cargo clippy --target wasm32-unknown-unknown -- -D warnings` clean for `harvest-common`, `store-contract`, `reputation-contract`, `mailbox-contract`, `harvest-delegate`.

## Impact on existing data

The store contract WASM hash changes (ghostkey-common 0.2.2 → 0.2.3 plus the verifier code change). Any test stores published before this PR are still addressable under the old contract id, but stores published after this PR have a new id. Harvest is in early development (no production stores), so this is acceptable scope.

## Out of scope

- `expected_requestor` is hardcoded rather than carried in `StoreParameters` because every store today must come from the same Harvest webapp. If we ever fork or want per-store flexibility, promoting it to a wire-additive `#[serde(default)] Option<SignatureRequestor>` field is straightforward.
- Vault "Manage app permissions" UI: ghostkeys PR #7 deferred this to a follow-up. Until it ships, users approve a `RequestAnyAccess` grant once and it persists; revocation requires invoking `RevokePermission` from a CLI. Filed as a follow-up.

## Fixes

Closes the cross-app ghostkey access gap that was blocking Harvest from being usable.

[AI-assisted - Claude]