### PR TITLE
ci: name the acknowledgement label in the drift guard's failure output

### DIFF
--- a/.github/workflows/contract-drift.yml
+++ b/.github/workflows/contract-drift.yml
@@ -44,6 +44,12 @@ on:
     # matters as much as `labeled`: removing the acknowledgement has to turn the
     # check red again rather than leaving a stale green.
     types: [opened, synchronize, reopened, labeled, unlabeled]
+    # The paths filter applies to every activity type, label events included.
+    # That is the behaviour we want: labelling a PR that touches none of these
+    # paths cannot have moved an address, so the job does not need to run and
+    # does not. The filter is not a hole in the gate either -- a PR that DOES
+    # touch them always runs the job on its own push, so the label event is
+    # only ever re-evaluating a check that already ran.
     paths:
       # Everything that can change the compiled bytes. `ui/**` is absent on
       # purpose: the UI is not a dependency of the contracts or the delegate.
@@ -191,7 +197,7 @@ jobs:
               echo "unchanged: $a  $h"
               echo "| \`$a\` | \`${b:0:16}…\` | \`${h:0:16}…\` | unchanged |" >> "$GITHUB_STEP_SUMMARY"
             else
-              echo "::error::$a RE-KEYS: $b -> $h"
+              echo "::error::$a RE-KEYS: $b -> $h  (see the job summary; label this PR contract-rekey-acknowledged if the re-key is intended)"
               echo "| \`$a\` | \`${b:0:16}…\` | \`${h:0:16}…\` | :warning: **MOVED** |" >> "$GITHUB_STEP_SUMMARY"
               moved=1
             fi
@@ -202,6 +208,11 @@ jobs:
             echo "No address moved." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
+
+          # Say the remedy in the log too, not only in the job summary. Someone
+          # reading a red check should not have to open the workflow file to
+          # find out what to do about it.
+          echo "::error::At least one contract or delegate address moved. State stored under the old address is not reachable from the new one. If the re-key is UNINTENDED, pin the dependency so the bytes stay put. If it is INTENDED, plan the migration and then add the label 'contract-rekey-acknowledged' to this PR -- applying it re-runs this check, no push needed."
 
           {
             echo "A moved code hash means the contract or delegate lives at a new address."
@@ -240,7 +251,7 @@ jobs:
             exit 0
           fi
           echo "::error::this PR changes: $changed"
-          echo "Both determine the compiled bytes, so every contract and delegate address moves."
+          echo "::error::Both determine the compiled bytes, so every contract and delegate address moves. If that is intended, add the label 'contract-rekey-acknowledged' to this PR -- applying it re-runs this check, no push needed."
           if [ "$ACKNOWLEDGED" = "true" ]; then
             echo "::warning::acknowledged via the contract-rekey-acknowledged label"
             exit 0


### PR DESCRIPTION
## Problem

Follow-up to #19. Two gaps in the drift guard, both found in review.

**1. A red check did not state its own remedy.** The `::error::` output named the
addresses that moved but not what to do about it. The label is the only way past
the gate, so a reviewer reading a red check had to open the workflow file to find
that out — and the escape hatch is exactly the part nobody should have to go
looking for.

**2. The `labeled` path was never actually demonstrated.** #19 added
`types: [opened, synchronize, reopened, labeled, unlabeled]`, but the run that
went green on that PR was triggered by a *push* that happened to carry the label,
not by the label event itself. So the fix was plausible rather than proven. It is
proven now — see Testing.

## Approach

- Both failing steps now print the remedy as `::error::` output, naming
  `contract-rekey-acknowledged` explicitly and saying that applying it re-runs the
  check with no push needed.
- A comment records why the `paths:` filter is correct for label events: it applies
  to every activity type, so labelling a PR that touches none of the listed paths
  does not run the job — which is right, because such a PR cannot have moved an
  address. It is not a hole either: a PR that *does* touch those paths always runs
  the job on its own push, so a label event only ever re-evaluates a check that has
  already run.

No behavioural change to the comparison itself.

## Testing

The label path, demonstrated end to end on this PR with **no code push between
states** — a temporary commit downgraded `chrono` one patch release so the check
was genuinely red, and every transition below was caused by a label event alone:

| # | event | trigger | result |
|---|---|---|---|
| 1 | push (temp downgrade present) | `synchronize` | red — four addresses moved |
| 2 | label applied | `labeled` | **green**, no push |
| 3 | label removed | `unlabeled` | **red again**, no push |
| 4 | temp commit dropped, no label | `synchronize` | green |

Run links in the comment below. Step 3 is the one that matters as much as step 2:
removing an acknowledgement re-asserts the gate rather than leaving the last green
result standing.

[AI-assisted - Claude]
