### PR TITLE
fix(ci): drop the drift job's paths filter so its required check always reports

### DIFF
--- a/.github/workflows/contract-drift.yml
+++ b/.github/workflows/contract-drift.yml
@@ -64,32 +64,49 @@ on:
     # matters as much as `labeled`: removing the acknowledgement has to turn the
     # check red again rather than leaving a stale green.
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    # The paths filter applies to every activity type, label events included.
-    # That is the behaviour we want: labelling a PR that touches none of these
-    # paths cannot have moved an address, so the job does not need to run and
-    # does not. The filter is not a hole in the gate either -- a PR that DOES
-    # touch them always runs the job on its own push, so the label event is
-    # only ever re-evaluating a check that already ran.
-    paths:
-      # Everything that can change the compiled bytes. `ui/**` is absent on
-      # purpose: the UI is not a dependency of the contracts or the delegate.
-      # `ui/public/contracts/**` IS here, because editing a committed artifact
-      # is a re-key by definition.
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "rust-toolchain.toml"
-      - "common/**"
-      - "contracts/**"
-      - "delegates/**"
-      - "ui/public/contracts/**"
-      - "scripts/build-contract-wasm.sh"
-      - ".github/workflows/contract-drift.yml"
+    # THERE IS DELIBERATELY NO `paths:` FILTER, and adding one back breaks every
+    # unrelated pull request.
+    #
+    # This job's name is a REQUIRED status check in the repository ruleset
+    # "Ensure CI passes before merge". A required check that never reports is
+    # not treated as satisfied -- it is treated as missing, and GitHub reports
+    # the pull request as BLOCKED with no failing check to point at. A `paths:`
+    # filter makes the job not run at all on a pull request that touches none
+    # of those paths, so such a pull request can never merge.
+    #
+    # That is not hypothetical: the filter and the ruleset coexisted for a day,
+    # and PR #27 (a Makefile-only change) sat MERGEABLE with four green checks
+    # and mergeStateStatus BLOCKED, because the fifth required check had no
+    # reason to run and so never reported.
+    #
+    # The earlier reasoning here was sound in isolation -- a pull request that
+    # touches no build input cannot have moved an address, so the work is
+    # pointless -- and it is still true. It is just not a reason to SKIP the
+    # job, because "pointless work" and "check that never reports" are settled
+    # by different mechanisms. The job now always runs and, on such a pull
+    # request, builds both sides to identical bytes and reports green, which is
+    # the correct answer rather than the absent one.
+    #
+    # The cost is real (two contract builds) and is paid on pull requests that
+    # cannot have moved an address. It is accepted here rather than reintroduced
+    # as skip-logic: this repository's characteristic defect is a guard that
+    # reports success while measuring nothing, and a hand-written path
+    # comparison inside the job would be exactly that shape -- one wrong pattern
+    # and a real re-key merges under a green check. `Swatinem/rust-cache`
+    # absorbs most of the cost, and dependabot's pull requests touch
+    # `Cargo.lock`, so they would run the job under either arrangement.
   workflow_dispatch:
 
 # Note there is no `push: main` trigger. After a merge the comparison has
 # nothing actionable left to say -- the PR is the gate. That does mean a direct
-# push to main bypasses this check entirely, which is an argument for requiring
-# this check in branch protection (main is unprotected as of this writing).
+# push to main bypasses this check entirely.
+#
+# The repository ruleset "Ensure CI passes before merge" now lists this job's
+# name among its required status checks, which closes that gap for anything
+# arriving through a pull request. It is also what makes the absence of a
+# `paths:` filter above load-bearing rather than merely wasteful: required and
+# path-filtered are a combination that blocks every pull request the filter
+# excludes.
 
 jobs:
   wasm-address-drift:
@@ -168,8 +185,10 @@ jobs:
           # the other's artifacts. The absolute paths differ between the two
           # trees, which is harmless ONLY because build-contract-wasm.sh
           # remaps them -- if that remapping is ever removed this comparison
-          # becomes noise, so the script's path is in this workflow's `paths:`
-          # filter and a change to it requires the acknowledgement label.
+          # becomes noise. A change to that script is therefore itself a build
+          # input: it runs this job (which now runs on every pull request) and,
+          # if the remapping change moves an address, needs the acknowledgement
+          # label like any other re-key.
           base_dir="$RUNNER_TEMP/base"
           # `fetch-depth: 0` normally leaves the base commit present, but a
           # narrow fetch configuration would not. Fetch it explicitly rather

--- a/.github/workflows/contract-drift.yml
+++ b/.github/workflows/contract-drift.yml
@@ -98,15 +98,20 @@ on:
   workflow_dispatch:
 
 # Note there is no `push: main` trigger. After a merge the comparison has
-# nothing actionable left to say -- the PR is the gate. That does mean a direct
-# push to main bypasses this check entirely.
+# nothing actionable left to say -- the PR is the gate.
 #
-# The repository ruleset "Ensure CI passes before merge" now lists this job's
-# name among its required status checks, which closes that gap for anything
-# arriving through a pull request. It is also what makes the absence of a
-# `paths:` filter above load-bearing rather than merely wasteful: required and
-# path-filtered are a combination that blocks every pull request the filter
-# excludes.
+# The repository ruleset "Ensure CI passes before merge" lists this job's name
+# among its required status checks, targets `~DEFAULT_BRANCH`, is `active`, and
+# has an empty `bypass_actors`. An earlier version of this note said a direct
+# push to main "bypasses this check entirely"; that was written before the
+# ruleset existed and is not asserted here, because it has not been tested
+# against it and required status checks are not only a pull-request mechanism.
+# What this job is designed around, and what is verified, is the pull-request
+# path.
+#
+# The ruleset is also what makes the absence of a `paths:` filter above
+# load-bearing rather than merely wasteful: required and path-filtered are a
+# combination that blocks every pull request the filter excludes.
 
 jobs:
   wasm-address-drift:


### PR DESCRIPTION
## Problem

The repository ruleset **"Ensure CI passes before merge"** (added 2026-09-05) requires four status checks, one of which is this workflow's job name, `no contract or delegate address moved`. The workflow also carried a `paths:` filter listing the build inputs.

Those two are incompatible. On a pull request touching none of those paths the job does not run, so the required check never reports — and a required check that never reports is treated as **missing**, not satisfied. GitHub then shows the pull request as `BLOCKED` while displaying no failing check, so there is nothing for a reader to act on.

This blocked every pull request that avoids the build inputs: docs, CI, UI, tooling.

Observed on #27, a Makefile-only change:

```
mergeStateStatus: BLOCKED
reviewDecision:   ''
fmt, clippy, test                          -> SUCCESS
contracts, delegate and UI build to wasm   -> SUCCESS
committed contract wasm matches a fresh build -> SUCCESS
license/cla                                -> SUCCESS
```

Four green, and the fifth required check absent because it had no reason to run.

## Approach

Remove the `paths:` filter; the job always runs.

The filter's original reasoning was sound and this change does not dispute it — a pull request that touches no build input genuinely cannot have moved an address, so the two contract builds really are pointless work there. But that is an argument about **cost**, and the ruleset is asking a different question: does the check **report**. Skipping settles the first by breaking the second.

**Why not skip-logic inside the job instead?** That was the alternative: always trigger, compute whether relevant paths changed, exit early if not. It keeps the cost saving, and I rejected it. This repository's characteristic defect is a guard that reports success while measuring nothing — the `paths:` filter comment itself records one, where `StoreParameters` shed two fields, took its CBOR from 109 to 56 bytes, re-keyed every published store, and both drift guards truthfully reported "unchanged". A hand-written path comparison inside the job is exactly that shape: one wrong pattern and a genuine re-key merges under a green check.

The change as made can only ever add checking, never remove it, which is the property worth having in a guard.

The cost is real and accepted. `Swatinem/rust-cache` absorbs most of it, and dependabot's pull requests touch `Cargo.lock`, so they run the job under either arrangement.

## Also fixed

Two comments this change falsifies, since stale comments asserting properties the code lacks are the other recurring defect here:

- the note claiming `main` is unprotected and that requiring this check would be an argument for future work — the ruleset now requires it;
- the note in the merge-base build step justifying itself by `build-contract-wasm.sh` being in the `paths:` filter, which no longer exists. A change to that script still runs this job, because everything now does.

## Testing

No test is possible for a workflow trigger short of running it. The verifiable claims:

- the YAML parses and `pull_request` now has only `types`, no `paths`;
- the job's `name:` is `no contract or delegate address moved`, matching the required-check string in the ruleset exactly — if that string ever drifts, the check goes missing again and the same deadlock returns;
- this PR touches `.github/workflows/contract-drift.yml`, which was **in** the old filter, so the job runs on this PR under the old rules too. That is what makes this fix able to merge while the bug it fixes is still in effect.

After this lands, #27 needs a rebase to pick up the workflow in its merge commit before its check will report.

[AI-assisted - Claude]

https://claude.ai/code/session_016JvRfeu5PyhAXMZdBWqqop
