### PR TITLE
fix(bitcoin): correct stale addressing constants, and refuse to publish stale ones

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -136,6 +136,42 @@ set -e
 export FREENET_NODE_URL
 echo "Publishing to $FREENET_NODE_URL"
 
+# The Bitcoin ADDRESSING constants are pinned at build time (the gateway CSP
+# forbids asking a bridge at runtime -- harvest#29), so a contract rebuild
+# re-keys them and this build goes quietly wrong. That happened: harvest#30,
+# stale by five generations, and it did NOT fail silent. The superseded tip
+# contract still exists and still holds its last state, so the published app
+# showed a chain tip ~400 blocks old as though it were live, and every invoice
+# named an address contract that was never published.
+#
+# So check before publishing, which is the moment the cost is incurred. This
+# cannot live in CI -- there is no bridge there.
+#
+# Exit 2 means "could not check" (no bridge reachable) and is NOT treated as a
+# pass, because recording "I could not look" as "it is fine" is the exact
+# defect being guarded against. Override deliberately if you must.
+set +e
+./scripts/check-bitcoin-constants.sh
+CHECK_RC=$?
+set -e
+if [ "$CHECK_RC" -eq 1 ]; then
+  echo "" >&2
+  echo "error: refusing to publish -- see the mismatch above." >&2
+  exit 1
+elif [ "$CHECK_RC" -eq 2 ]; then
+  if [ "${HARVEST_SKIP_BRIDGE_CHECK:-}" = "1" ]; then
+    echo "WARNING: publishing WITHOUT having checked the Bitcoin constants" >&2
+    echo "         (HARVEST_SKIP_BRIDGE_CHECK=1). If they are stale, this build" >&2
+    echo "         will show stale chain data as live. See harvest#30." >&2
+  else
+    echo "" >&2
+    echo "error: could not verify the Bitcoin constants against a bridge, so" >&2
+    echo "       refusing to publish. Start a bridge, set HARVEST_BRIDGE_URL," >&2
+    echo "       or set HARVEST_SKIP_BRIDGE_CHECK=1 to publish unverified." >&2
+    exit 1
+  fi
+fi
+
 # fdev EXITS 0 ON A FAILED PUBLISH -- observed 2026-09-06, printing
 # "Error: Failed to receive response" and returning 0. So `set -e` does not
 # catch it and the success line below would print over a failure. Confirm from

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -170,6 +170,20 @@ elif [ "$CHECK_RC" -eq 2 ]; then
     echo "       or set HARVEST_SKIP_BRIDGE_CHECK=1 to publish unverified." >&2
     exit 1
   fi
+elif [ "$CHECK_RC" -ne 0 ]; then
+  # ANY other exit code means the check did not run to a verdict at all: not
+  # executable (126), not found or bad interpreter (127), killed by a signal
+  # (128+n). Without this branch those fall through to publish, which is the
+  # precise failure the check exists to prevent -- "I could not look" recorded
+  # as "it is fine" -- reintroduced one level up in the wrapper that calls it.
+  #
+  # Found in review. Trigger is mundane: a checkout that drops the executable
+  # bit (core.fileMode=false) silently defeats the entire gate.
+  echo "" >&2
+  echo "error: scripts/check-bitcoin-constants.sh did not run to a verdict" >&2
+  echo "       (exit $CHECK_RC). Refusing to publish rather than assuming the" >&2
+  echo "       constants are fine. Check the script is present and executable." >&2
+  exit 1
 fi
 
 # fdev EXITS 0 ON A FAILED PUBLISH -- observed 2026-09-06, printing

--- a/scripts/check-bitcoin-constants.sh
+++ b/scripts/check-bitcoin-constants.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Compare this build's Bitcoin ADDRESSING constants against a running bridge.
+#
+# WHY THIS EXISTS
+#
+# A contract lives at BLAKE3(BLAKE3(wasm) || parameters), so rebuilding the
+# Bitcoin contracts re-keys them. Harvest pins the resulting values as
+# build-time constants in ui/src/gateway/bitcoin_config.rs, because the gateway
+# CSP forbids the published app from asking a bridge at runtime (harvest#29) --
+# correctly, since a Freenet webapp reaches the network through its node.
+#
+# On 2026-09-06 both constants were found stale, one by five generations
+# (harvest#30). Nothing caught it: they were WELL-FORMED, and the only test
+# asserted well-formedness. The failure was not silence, which is what makes it
+# nasty -- the superseded tip contract still exists and still holds its last
+# state, so the app rendered a chain tip ~400 blocks old as though it were
+# current, and every invoice named an address contract that was never
+# published.
+#
+# This script is the stopgap gate until pointer records land. It cannot run in
+# CI (there is no bridge there), so it runs at PUBLISH time, which is the
+# moment the cost is actually incurred.
+#
+# EXIT CODES -- distinguished on purpose:
+#   0  checked, and the constants match
+#   1  checked, and they DISAGREE, or a constant could not be read at all
+#   2  could NOT check (no bridge reachable)
+#
+# 2 is separate from 0 because "I could not look" must never be recorded as "it
+# is fine". That conflation is the defect this whole file exists to answer.
+
+set -uo pipefail
+
+BRIDGE_URL="${1:-${HARVEST_BRIDGE_URL:-http://127.0.0.1:8431}}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG="$REPO_ROOT/ui/src/gateway/bitcoin_config.rs"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "error: cannot find $CONFIG" >&2
+  exit 1
+fi
+
+# Read the constants out of the source. Anchored so a rename or reshuffle makes
+# the extraction FAIL rather than silently return nothing -- an empty value
+# compared against an empty value would otherwise "match".
+#
+# The tip id is read from the Signet arm specifically; the constant is a
+# per-network match and grepping the whole function would pick up whichever
+# arm came first.
+built_tip="$(sed -n 's/.*BitcoinNetwork::Signet => Some("\([1-9A-HJ-NP-Za-km-z]*\)").*/\1/p' "$CONFIG" | head -1)"
+built_addr="$(sed -n '/pub const ADDRESS_CONTRACT_CODE_HASH_HEX/,/;/p' "$CONFIG" \
+              | sed -n 's/.*"\([0-9a-f]\{64\}\)".*/\1/p' | head -1)"
+
+if [ -z "$built_tip" ] || [ -z "$built_addr" ]; then
+  echo "error: could not read the constants out of $CONFIG." >&2
+  echo "       tip='$built_tip' addr='$built_addr'" >&2
+  echo "       This script's extraction has drifted from the source. Fix the" >&2
+  echo "       extraction -- do NOT treat an unreadable constant as a pass." >&2
+  exit 1
+fi
+
+status="$(curl -fsS --max-time 10 "$BRIDGE_URL/v1/status" 2>/dev/null)" || status=""
+if [ -z "$status" ]; then
+  echo "could not reach a bridge at $BRIDGE_URL, so the constants were NOT checked." >&2
+  echo "  built tip contract (signet): $built_tip" >&2
+  echo "  built address code hash:     $built_addr" >&2
+  echo "  Start a bridge, pass one as \$1, or set HARVEST_BRIDGE_URL." >&2
+  exit 2
+fi
+
+live_tip="$(printf '%s' "$status" | python3 -c '
+import json,sys
+d=json.load(sys.stdin)
+for n in d.get("networks",[]):
+    if n.get("network")=="signet":
+        print(n.get("tip_contract_id") or "")
+        break
+' 2>/dev/null)"
+live_addr="$(printf '%s' "$status" | python3 -c '
+import json,sys
+print(json.load(sys.stdin).get("address_code_hash") or "")
+' 2>/dev/null)"
+
+if [ -z "$live_tip" ] || [ -z "$live_addr" ]; then
+  echo "error: the bridge at $BRIDGE_URL answered, but not with the fields" >&2
+  echo "       this check needs (signet tip_contract_id, address_code_hash)." >&2
+  echo "       Treating that as a failure rather than a pass." >&2
+  exit 1
+fi
+
+rc=0
+if [ "$built_tip" != "$live_tip" ]; then
+  echo "MISMATCH: signet tip contract" >&2
+  echo "  built:  $built_tip" >&2
+  echo "  bridge: $live_tip" >&2
+  rc=1
+fi
+if [ "$built_addr" != "$live_addr" ]; then
+  echo "MISMATCH: address contract code hash" >&2
+  echo "  built:  $built_addr" >&2
+  echo "  bridge: $live_addr" >&2
+  rc=1
+fi
+
+if [ "$rc" -ne 0 ]; then
+  echo "" >&2
+  echo "This build's addressing constants disagree with the bridge at $BRIDGE_URL." >&2
+  echo "Publishing it would show stale chain data as though it were live and" >&2
+  echo "issue invoices that can never be observed as paid. See harvest#30." >&2
+  echo "Update ui/src/gateway/bitcoin_config.rs before publishing." >&2
+  exit 1
+fi
+
+echo "bitcoin constants match the bridge at $BRIDGE_URL"
+echo "  signet tip contract:      $built_tip"
+echo "  address contract code hash: $built_addr"

--- a/ui/src/gateway/bitcoin_config.rs
+++ b/ui/src/gateway/bitcoin_config.rs
@@ -40,12 +40,43 @@
 //!
 //! **This is a stopgap and it has the exact staleness problem the constant was
 //! meant to avoid**: a contract rebuild re-keys the tip contract and this file
-//! goes quietly wrong. The durable fix is a POINTER RECORD -- a fixed-address,
-//! author-signed contract naming the current code hash, read over the
-//! WebSocket like any other contract, which is what `freenet-migrate`'s
-//! pointer mechanism exists for and what ghostkeys already does. Until that is
-//! in place, treat the constants below as needing an update whenever
-//! `legacy_contracts.toml` gains an entry.
+//! goes quietly wrong.
+//!
+//! That is not a warning about the future. It HAPPENED, and was found on
+//! 2026-09-06 (harvest#30): both constants below were stale, one of them by
+//! five generations. Record what the failure actually looked like, because it
+//! is not what this file predicted:
+//!
+//!   * It did NOT report "this network has no data yet". The superseded tip
+//!     contract still exists on the network and still holds the last state it
+//!     was given, so the published app rendered a chain tip ~400 blocks old,
+//!     frozen three days, indistinguishable from live data.
+//!   * The stale address code hash was stamped onto every invoice issued,
+//!     naming an address contract that was never published -- so a payment
+//!     could never be observed, and nothing about the invoice looked wrong.
+//!   * The trusted-bridge constant was CORRECT throughout. Trust was right and
+//!     addressing was wrong, which is why nothing errored: the app believed the
+//!     right signer and looked in the wrong places.
+//!
+//! **A stale content-addressed constant does not fail quiet, it fails
+//! plausible.** The old address is a real contract holding real, once-valid
+//! state. That is worse than an empty panel and is the reason "only
+//! well-formedness is asserted" was an expensive gap.
+//!
+//! The durable fix is a POINTER RECORD -- a fixed-address, author-signed
+//! contract naming the current code hash, read over the WebSocket like any
+//! other contract, which is what `freenet-migrate`'s pointer mechanism exists
+//! for and what ghostkeys already does. Ghostkeys is a working reference: it
+//! carries `pointer-records.toml`, `scripts/sign-pointer-records.sh`, and a CI
+//! `check-pointer-freshness` job that fails the PR when an artifact's WASM
+//! changed and no new record was signed. That CI gate is precisely what is
+//! missing here. `freenet-bitcoin` already ships `generation/pointer-v1.wasm`
+//! but has no records config yet.
+//!
+//! Until that is in place, treat the constants below as needing an update
+//! whenever `freenet-bitcoin`'s `legacy/` registries gain an entry -- and note
+//! that appending to those registries is exactly what a re-key does, so an
+//! entry appearing there IS the signal that this file is now wrong.
 
 use freenet_bitcoin_common::BitcoinNetwork;
 
@@ -60,7 +91,19 @@ pub fn well_known_tip_contract_id(network: BitcoinNetwork) -> Option<&'static st
         // bridge] } plus the tip contract's code hash.
         //
         // Re-derive with: curl -s <bridge>/v1/status
-        BitcoinNetwork::Signet => Some("B24HMUFasG3Yd1EJxfzb3qTPos1tLMiKo5gYiKwaihqT"),
+        //
+        // UPDATED 2026-09-06. The previous value, B24HMUFasG3Yd1EJxfzb3qTPos1t
+        // LMiKo5gYiKwaihqT, had been superseded and the failure was NOT the
+        // "this network has no data yet" the module docs predicted. That old
+        // contract still exists on the network and still holds the last state
+        // it was given, so the published app rendered a chain tip ~400 blocks
+        // stale, frozen three days, as if it were current -- while the bridge
+        // was at height 320955. See harvest#30.
+        //
+        // A stale address here does not go quiet. It points at a real contract
+        // holding real, once-valid, now-frozen state, and confirmation depth is
+        // measured against that tip.
+        BitcoinNetwork::Signet => Some("FXFgLKfuMm3NPtzWg3Ghgt5otv4Yo7N4CWGDvHpVeZMm"),
         BitcoinNetwork::Regtest => None,
     }
 }
@@ -109,8 +152,15 @@ pub const TRUSTED_BRIDGE_ID_BS58: &str = "4MZnDAQWccEWXBUb1wt4iTEkDi6Z2MCcZ9WQN1
 /// Needed to compute a watched address's contract id locally, since the
 /// gateway CSP rules out asking the bridge. Goes stale on any contract
 /// rebuild -- see the module docs on the pointer-record fix.
+///
+/// UPDATED 2026-09-06 from `3b5f1df2...`, which `freenet-bitcoin`'s
+/// `legacy/address_contract.toml` lists as generation **A3** -- a file whose
+/// header states it records ONLY superseded generations. The deployed bridge
+/// reports A8. So this build was stamping five-generations-old code hashes
+/// onto every invoice it issued, naming an address contract that was never
+/// published. See harvest#30.
 pub const ADDRESS_CONTRACT_CODE_HASH_HEX: &str =
-    "3b5f1df28497b1cfb365798cb86fc87a7e45480d47c79e22f09b9f801e95463f";
+    "cd2ae7418e3b29c2770fab549763b8a268d54787a86a9bfad5b59ca3d2023555";
 
 /// Which networks this build can actually settle a payment on.
 ///
@@ -193,6 +243,18 @@ mod tests {
     /// a rebuild of a contract this workspace does not build -- and it cannot
     /// be checked here, because the artifact is not bundled. Only well-formedness
     /// is asserted.
+    ///
+    /// **That gap was not hypothetical and it has since been paid.** On
+    /// 2026-09-06 both constants were found stale against the deployed bridge
+    /// (harvest#30) -- well-formed throughout, so this test passed the entire
+    /// time. The paragraph above described the failure accurately in advance
+    /// and nothing acted on it, which is the argument for closing it with a
+    /// pointer record rather than a sharper comment.
+    ///
+    /// Do not be tempted to "fix" this by asserting the constants equal
+    /// specific literals: that tests the file against itself and would also
+    /// have passed. The check has to compare against something outside this
+    /// repository -- the bridge, or a pointer record resolved over the node.
     #[test]
     fn the_builds_bitcoin_constants_parse() {
         let bridges = default_trusted_bridges(default_network())


### PR DESCRIPTION
Fixes the immediate breakage in #30 and adds the gate that stops it recurring on the next contract rebuild.

## Problem

Harvest's build-time Bitcoin **addressing** constants no longer matched the deployed bridge. Both wrong values were well-formed, so every existing check passed.

| constant | was | now |
|---|---|---|
| `well_known_tip_contract_id(Signet)` | `B24HMUFa…` | `FXFgLKfu…` |
| `ADDRESS_CONTRACT_CODE_HASH_HEX` | `3b5f1df2…` (generation **A3**) | `cd2ae741…` (**A8**) |
| `TRUSTED_BRIDGE_ID_BS58` | *correct* | unchanged |

The split is why nothing errored: the app trusted the right signer and looked in the wrong places.

## The failure was not what the code predicted

The module docs anticipated this going wrong as *"this network has no data yet"*. Observed in the published app instead:

```
#320557   34 tx     3 days ago
#320556   903 tx    3 days ago
...
```

while the bridge was at height **320955**. The superseded tip contract still exists on the network and still holds the last state it was given, so Payments rendered a tip ~400 blocks stale **as though it were current**. Confirmation depth is measured against that tip.

Runtime evidence from the deployed app, not inferred from source:

```
INFO ui/src/gateway/delegate_api.rs:51  GET contract (subscribe=true):
     ContractInstanceId("B24HMUFasG3Yd1EJxfzb3qTPos1tLMiKo5gYiKwaihqT")
```

**A stale content-addressed constant does not fail quiet, it fails plausible.** The comments are updated to say so, because the old wording would send the next reader hunting for silence.

Separately, `state.rs:863` stamped the stale code hash onto every invoice, naming an address contract that was never published — unpayable, and nothing about it looked wrong.

## Verification of the values

Not taken from the bridge's self-report alone, since this file's own docs warn against trusting a bridge for addressing:

- the bridge's `/v1/status` reports both;
- `freenet-bitcoin/legacy/address_contract.toml` lists `3b5f1df2…` as **A3**, in a file whose header says it records *only superseded* generations, with A8 = `cd2ae741…`;
- `fdev diagnostics` lists both tip contracts as distinct live keys on the node — two real contracts, and the build watched the one nothing writes to.

## The gate

`scripts/check-bitcoin-constants.sh` compares the pinned constants against a running bridge; `publish-harvest` calls it before publishing. That is the moment the cost is incurred and the only place it *can* run — CI has no bridge.

Three exit codes, deliberately distinct:

| code | meaning | publish task |
|---|---|---|
| 0 | checked, match | proceeds |
| 1 | checked, disagree — or a constant could not be read | refuses |
| 2 | could **not** check (no bridge) | refuses, unless `HARVEST_SKIP_BRIDGE_CHECK=1`, which warns loudly |

`2` is separate from `0` on purpose: recording *"I could not look"* as *"it is fine"* is the exact defect being guarded against.

Extraction **fails closed** — rename or move a constant and the script says its own extraction has drifted and exits 1, rather than comparing empty to empty and calling it a match. That is how a check like this normally rots.

## Testing

Verified by making it **fail**, not only pass — the lesson from #27 in this same series, where a success gate was watched working once on the one path it would never meet again.

| case | result |
|---|---|
| stale constants, exactly as shipped | **exit 1**, both mismatches named — it would have caught #30 |
| unreachable bridge | **exit 2**, states the constants were NOT checked |
| constant renamed (extraction drift) | **exit 1**, "extraction has drifted" |
| current constants | exit 0 |

And the publish wiring against a stubbed check: `0` publishes, `1` refuses, `2` refuses with instructions, `2` + override warns and proceeds.

Existing `bitcoin_config` tests still pass (4/4) — as they did *before* this fix, which is the documented gap: they assert well-formedness only.

## What this is not

A stopgap. It works only where a bridge is reachable, and it trusts that bridge to describe itself. The durable answer is a **pointer record** read over the node like any other contract. `freenet/ghostkeys` already runs that pattern end to end — `pointer-records.toml`, a signer script, and a CI `check-pointer-freshness` job that fails a PR when an artifact's WASM changed and no new record was signed. That gate is exactly what is missing here, and `freenet-bitcoin` already ships `generation/pointer-v1.wasm` but has no records config.

#30 stays open for that.

[AI-assisted - Claude]

https://claude.ai/code/session_016JvRfeu5PyhAXMZdBWqqop
