### PR TITLE
fix(publish): clean the dx output and gate the archive against stale copies

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -37,6 +37,19 @@ description = "Build the Dioxus UI"
 dependencies = ["sync-wasm"]
 script = '''
 set -e
+# WIPE THE OUTPUT DIRECTORY FIRST.
+#
+# dx writes CONTENT-HASHED asset filenames, so a rebuild lands BESIDE its
+# predecessor instead of replacing it. Nothing prunes the old one and
+# compress-webapp tars the whole directory, so without this the bundle is
+# append-only across builds -- it grows a full UI wasm on every publish. The
+# live container was measured carrying TEN copies, 37.7 MB uncompressed, where
+# Delta and River carry one each (harvest#4).
+#
+# Safe to wipe: everything here is regenerated. dx re-copies ui/public/* (which
+# is where sync-wasm stages contracts/), and the two fixed-name assets are
+# re-copied below.
+rm -rf target/dx/harvest-ui/${BUILD_PROFILE}/web/public
 cd ui && dx build --${BUILD_PROFILE}
 # dx doesn't copy CSS from assets/ to the build output root, so copy
 # manually. Path is relative to `ui/` because we cd'd above and the
@@ -68,7 +81,19 @@ dependencies = ["build-ui"]
 script = '''
 mkdir -p target/webapp
 cd target/dx/harvest-ui/${BUILD_PROFILE}/web/public && tar -cJf ../../../../../webapp/webapp.tar.xz *
+cd - > /dev/null
 echo "Compressed webapp to target/webapp/webapp.tar.xz"
+
+# Gate the ARCHIVE, not the build directory, and do it here so a bad archive
+# can never reach sign-webapp -- an archive that has been signed has already
+# been given an identity, and refusing it afterwards is a worse place to find
+# out.
+#
+# The clean above should make this unnecessary. That is exactly why it is here:
+# a clean step can be skipped, reordered, or quietly broken by a later edit,
+# whereas a gate that refuses the archive cannot be skipped silently. The clean
+# is the fix; this is the thing that notices when the fix stops working.
+./scripts/check-webapp-bundle.sh target/webapp/webapp.tar.xz
 '''
 
 [tasks.sign-webapp]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -93,7 +93,8 @@ echo "Compressed webapp to target/webapp/webapp.tar.xz"
 # a clean step can be skipped, reordered, or quietly broken by a later edit,
 # whereas a gate that refuses the archive cannot be skipped silently. The clean
 # is the fix; this is the thing that notices when the fix stops working.
-./scripts/check-webapp-bundle.sh target/webapp/webapp.tar.xz
+./scripts/check-webapp-bundle.sh target/webapp/webapp.tar.xz \
+  "target/dx/harvest-ui/${BUILD_PROFILE}/web/public"
 '''
 
 [tasks.sign-webapp]

--- a/scripts/check-webapp-bundle.sh
+++ b/scripts/check-webapp-bundle.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+# Publish gate: refuse a webapp archive that is not self-consistent.
+#
+# WHY THIS EXISTS
+#
+# dx writes CONTENT-HASHED asset filenames, so a changed build lands beside its
+# predecessor rather than replacing it. Nothing prunes the old one and the
+# publish task tars the whole directory, so the bundle is append-only across
+# builds: it grows a full UI wasm on every publish, indefinitely. The live
+# Harvest container was measured carrying TEN copies, 37.7 MB uncompressed,
+# where Delta and River carry one each (harvest#4).
+#
+# The wasted bytes are the smaller cost. With several wasms in the bundle, "did
+# my fix ship?" can no longer be answered by grepping the bundle, because a grep
+# for a new symbol hits a stale copy just as readily as the live one. Checking
+# reachability here is what keeps grep-the-bundle an honest deploy check.
+#
+# Ported from delta's scripts/check-webapp-bundle.sh (delta#70, delta#46),
+# which was written against the identical dx behaviour. Both incidents its
+# comments describe are load-bearing; read them before simplifying anything
+# here.
+#
+# WHAT IT ASSERTS
+#
+# Every file in the archive is accounted for, in one of exactly two ways:
+#
+#   REQUIRED  - a fixed-name file the app needs at runtime. These cannot be
+#               covered by reachability: contracts/*.wasm are fetched via a path
+#               the app builds at run time, so their names appear nowhere in the
+#               bundle. Their absence is checked directly instead.
+#
+#   ACCOUNTED - carries a dx content hash in its name (check 0) AND is
+#               referenced, transitively, from index.html (check 1).
+#
+# Both are needed and neither is redundant: hash-shape catches an unhashed stray
+# whatever any file happens to contain, and reachability catches a HASHED orphan
+# from an earlier build -- the harvest#4 bug -- which hash-shape cannot
+# distinguish from the live one.
+set -euo pipefail
+
+ARCHIVE="${1:?usage: check-webapp-bundle.sh <webapp.tar.xz>}"
+[ -f "$ARCHIVE" ] || { echo "FAILED: no such archive: $ARCHIVE"; exit 1; }
+# Absolute: the checks below run from inside a temp extraction dir.
+ARCHIVE="$(cd "$(dirname "$ARCHIVE")" && pwd)/$(basename "$ARCHIVE")"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+tar -xJf "$ARCHIVE" -C "$WORK"
+cd "$WORK"
+
+fail() { echo "FAILED: $*"; exit 1; }
+
+# Fixed-name files the app needs. index.html is first because everything else
+# is judged relative to it. harvest-logo.svg is REQUIRED rather than a
+# reachability candidate because it is not content-hashed: it is copied in by
+# build-ui and referenced from harvest.css by a fixed name.
+REQUIRED=(
+    index.html
+    harvest.css
+    harvest-logo.svg
+    contracts/store_contract.wasm
+    contracts/reputation_contract.wasm
+    contracts/mailbox_contract.wasm
+    contracts/harvest_delegate.wasm
+    contracts/ghostkey_delegate.wasm
+)
+
+MISSING=()
+for f in "${REQUIRED[@]}"; do
+    [ -f "$f" ] || MISSING+=("$f")
+done
+if [ "${#MISSING[@]}" -gt 0 ]; then
+    echo "FAILED: the archive is missing ${#MISSING[@]} file(s) the app needs:"
+    printf '          %s\n' "${MISSING[@]}"
+    exit 1
+fi
+
+mapfile -t ALL < <(find . -type f -printf '%P\n' | sort)
+
+dir_of() { case "$1" in */*) printf '%s' "${1%/*}" ;; *) printf '' ;; esac; }
+
+CANDIDATES=()
+for f in "${ALL[@]}"; do
+    skip=""
+    for r in "${REQUIRED[@]}"; do [ "$f" = "$r" ] && { skip=1; break; }; done
+    [ -n "$skip" ] || CANDIDATES+=("$f")
+done
+[ "${#CANDIDATES[@]}" -gt 0 ] || fail "archive contains no app assets -- the build produced nothing"
+
+# CHECK 0: every non-required file must carry a dx content hash in its name.
+#
+# PRIMARY check because it involves no parsing, so nothing a file happens to
+# contain can talk it out of a refusal. In delta this caught dx's staged
+# UNHASHED wasm-bindgen output, which the reachability scan below had laundered
+# into "reachable" via a substring coincidence -- the loader legitimately
+# contains wasm-bindgen's default name. If dx ever changes its hash format this
+# starts refusing everything, which is loud rather than silent: the correct
+# direction for a publish gate to fail.
+UNHASHED=()
+for f in "${CANDIDATES[@]}"; do
+    [[ "${f##*/}" =~ -dxh[0-9a-f]+\.[A-Za-z0-9]+$ ]] || UNHASHED+=("$f")
+done
+if [ "${#UNHASHED[@]}" -gt 0 ]; then
+    echo "FAILED: ${#UNHASHED[@]} file(s) carry no dx content hash and are not required files:"
+    for f in "${UNHASHED[@]}"; do
+        echo "          $f ($(stat -c%s "$f") bytes)"
+    done
+    echo "        dx names every bundled asset <name>-dxh<hash>.<ext>. An unhashed"
+    echo "        file here is a stray, or a fixed-name file that belongs in"
+    echo "        REQUIRED above. See harvest#4."
+    exit 1
+fi
+
+# CHECK 1: transitive reachability from index.html, for orphans that DO carry a
+# hash (a previous build's asset, which check 0 cannot distinguish). Files are
+# scanned as text because the loader names its wasm. References resolve RELATIVE
+# TO THE REFERRER: a candidate is reached if the referrer contains its full
+# archive path, or its bare basename AND the two share a directory.
+declare -A REACHED=()
+FRONTIER=("index.html")
+while [ "${#FRONTIER[@]}" -gt 0 ]; do
+    current="${FRONTIER[0]}"
+    FRONTIER=("${FRONTIER[@]:1}")
+    current_dir="$(dir_of "$current")"
+    for f in "${CANDIDATES[@]}"; do
+        [ -n "${REACHED[$f]:-}" ] && continue
+        if grep -aqF -- "$f" "$current" \
+           || { [ "$(dir_of "$f")" = "$current_dir" ] && grep -aqF -- "${f##*/}" "$current"; }; then
+            REACHED[$f]=1
+            FRONTIER+=("$f")
+        fi
+    done
+done
+
+UNREACHED=()
+for f in "${CANDIDATES[@]}"; do
+    [ -n "${REACHED[$f]:-}" ] || UNREACHED+=("$f")
+done
+if [ "${#UNREACHED[@]}" -gt 0 ]; then
+    echo "FAILED: ${#UNREACHED[@]} file(s) in the bundle are unreachable from index.html:"
+    for f in "${UNREACHED[@]}"; do
+        echo "          $f ($(stat -c%s "$f") bytes)"
+    done
+    echo "        These are stale copies from earlier builds -- the harvest#4 bug."
+    echo "        Every published byte should be reachable. Clean the dx output"
+    echo "        directory and rebuild."
+    exit 1
+fi
+
+# The chain must actually resolve, so an asset-less bundle cannot pass check 1
+# vacuously.
+JS_REF=""
+for f in "${CANDIDATES[@]}"; do
+    case "$f" in *.js) if grep -aqF -- "${f##*/}" index.html; then JS_REF="$f"; break; fi ;; esac
+done
+[ -n "$JS_REF" ] || fail "index.html references no js in the bundle -- there is no entry point"
+
+WASM_REF=""
+for f in "${CANDIDATES[@]}"; do
+    case "$f" in *.wasm) if grep -aqF -- "${f##*/}" "$JS_REF"; then WASM_REF="$f"; break; fi ;; esac
+done
+[ -n "$WASM_REF" ] || fail "$JS_REF references no wasm in the bundle -- the loader has nothing to load"
+
+# Staleness guard: if the build output this archive was made from is still on
+# disk, the archive must describe it. Catches a gate inspecting a tarball from
+# an earlier build -- a gate that ran, but not against the thing being
+# published. Skipped when the tree is absent.
+BUILD_DIR="$(dirname "$ARCHIVE")/../dx/harvest-ui/release/web/public"
+if [ -d "$BUILD_DIR" ]; then
+    on_disk="$(find "$BUILD_DIR" -type f -printf '%P\n' | sort)"
+    in_archive="$(printf '%s\n' "${ALL[@]}")"
+    [ "$on_disk" = "$in_archive" ] || fail \
+        "archive contents do not match the build output at $BUILD_DIR -- this archive is stale"
+fi
+
+echo "Bundle OK: index.html -> $JS_REF -> $WASM_REF"
+echo "  ${#ALL[@]} file(s): ${#REQUIRED[@]} required, ${#CANDIDATES[@]} reachable from index.html"
+echo "  archive:   $(du -h "$ARCHIVE" | cut -f1) compressed"
+echo "  extracted: $(du -sh . | cut -f1)"

--- a/scripts/check-webapp-bundle.sh
+++ b/scripts/check-webapp-bundle.sh
@@ -38,7 +38,7 @@
 # distinguish from the live one.
 set -euo pipefail
 
-ARCHIVE="${1:?usage: check-webapp-bundle.sh <webapp.tar.xz>}"
+ARCHIVE="${1:?usage: check-webapp-bundle.sh <webapp.tar.xz> [build-dir]}"
 [ -f "$ARCHIVE" ] || { echo "FAILED: no such archive: $ARCHIVE"; exit 1; }
 # Absolute: the checks below run from inside a temp extraction dir.
 ARCHIVE="$(cd "$(dirname "$ARCHIVE")" && pwd)/$(basename "$ARCHIVE")"
@@ -164,8 +164,26 @@ done
 # Staleness guard: if the build output this archive was made from is still on
 # disk, the archive must describe it. Catches a gate inspecting a tarball from
 # an earlier build -- a gate that ran, but not against the thing being
-# published. Skipped when the tree is absent.
-BUILD_DIR="$(dirname "$ARCHIVE")/../dx/harvest-ui/release/web/public"
+# published.
+#
+# The build directory is passed in by the caller ($2) rather than guessed,
+# because guessing it means guessing the build profile. delta's original
+# hardcoded "release"; under any other profile that path simply would not
+# exist, and the `-d` test below would SKIP the guard silently rather than
+# report that it could not run -- a guard that measures nothing while looking
+# like it passed. compress-webapp passes the directory it actually tarred.
+#
+# When $2 IS given the directory must exist: the caller just built it, so its
+# absence is a real error rather than a reason to skip. The guess-and-skip path
+# is kept only for running this script by hand against an archive fetched from
+# elsewhere, where there is no build tree to compare against.
+if [ -n "${2:-}" ]; then
+    BUILD_DIR="$2"
+    [ -d "$BUILD_DIR" ] || fail "build directory $BUILD_DIR does not exist -- cannot verify the archive matches the build it came from"
+else
+    BUILD_DIR="$(dirname "$ARCHIVE")/../dx/harvest-ui/release/web/public"
+    [ -d "$BUILD_DIR" ] || echo "note: no build tree at $BUILD_DIR; skipping the staleness comparison"
+fi
 if [ -d "$BUILD_DIR" ]; then
     on_disk="$(find "$BUILD_DIR" -type f -printf '%P\n' | sort)"
     in_archive="$(printf '%s\n' "${ALL[@]}")"


### PR DESCRIPTION
Fixes #4.

## Problem

`dx` writes **content-hashed** asset filenames, so a rebuild lands *beside* its predecessor rather than replacing it. Nothing pruned the old one and `compress-webapp` tars the whole directory, so the bundle was append-only across builds — one full UI WASM per publish, indefinitely.

The live container was measured carrying **ten** copies, 37.7 MB uncompressed, where Delta and River carry one each.

The wasted bytes are the smaller cost. With several WASMs in the bundle, *"did my fix ship?"* can no longer be answered by grepping the bundle, because a grep for a new symbol hits a stale copy just as readily as the live one.

## Approach

Two changes, and the second is the one that lasts.

**1. `build-ui` wipes the dx output directory before building.** Safe because everything there is regenerated: dx re-copies `ui/public/*` (where `sync-wasm` stages `contracts/`), and the two fixed-name assets are re-copied after. Verified against a real build — contracts are present and correct in the output.

**2. `compress-webapp` gates the archive**, before `sign-webapp` can see it. An archive that has been signed already has an identity; refusing it afterwards is a worse place to find out.

**The clean should make the gate unnecessary. That is exactly why the gate is there.** A clean step can be skipped, reordered, or quietly broken by a later edit; a gate that refuses the archive cannot be skipped silently. The clean is the fix; the gate is what notices when the fix stops working. The issue makes this point and it is right.

## Why reachability, not a copy count

Ported from `delta/scripts/check-webapp-bundle.sh` (delta#70, delta#46), written against identical dx behaviour.

It asserts **transitive reachability from `index.html`** rather than "exactly one WASM":

- a count cannot distinguish a stale hashed orphan from the live one — which *is* the bug;
- reachability also catches an orphaned favicon, a stale `index.html` pointing at an old loader, a root-level orphan, and nested leftovers;
- a hardcoded "exactly 1" would break on a future dx that legitimately emits several chunks.

It **additionally** requires every non-fixed-name file to carry a dx content hash. Neither check is redundant: in delta, dx's staged *unhashed* `wasm-bindgen` output was laundered into "reachable" by a substring coincidence with the loader, which legitimately contains wasm-bindgen's default name. Hash-shape catches that by construction, whatever the matcher is later changed to.

Harvest's fixed-name set differs from delta's: `index.html`, `harvest.css`, `harvest-logo.svg`, and five `contracts/*.wasm`. `harvest-logo.svg` is REQUIRED rather than a reachability candidate because it is not content-hashed and is named from `harvest.css`.

## Testing

Verified by making it **fail**, not only pass:

| case | result |
|---|---|
| stale extra WASM beside the live one — **the #4 bug exactly** | refuses, naming the orphan and its size |
| unhashed stray (dx staged-output shape) | refuses |
| `contracts/store_contract.wasm` removed | refuses |
| real clean build via `cargo make compress-webapp` | **passes** — 10 files, 8 required, 2 reachable, 1.2M compressed |

The last row is a genuine end-to-end run, not a synthetic archive.

## Noticed while running this, not fixed here

The build log shows:

```
wasm-opt failed with status code signal: 6 (SIGABRT) (core dumped)
stdout: compile unit size was incorrect (this may be an unsupported version of DWARF)
```

dx continues and reports "Client build completed successfully", so **the shipped UI WASM is unoptimised**. It is 7,283,353 bytes — byte-for-byte the same size as the previous build, which indicates this has been failing on every build, not just this one.

Out of scope here; filed separately so it is not lost.

[AI-assisted - Claude]

https://claude.ai/code/session_016JvRfeu5PyhAXMZdBWqqop
