### PR TITLE
fix(publish): resolve the build directory before chdir, so the gate can find it

### DIFF
--- a/scripts/check-webapp-bundle.sh
+++ b/scripts/check-webapp-bundle.sh
@@ -43,6 +43,23 @@ ARCHIVE="${1:?usage: check-webapp-bundle.sh <webapp.tar.xz> [build-dir]}"
 # Absolute: the checks below run from inside a temp extraction dir.
 ARCHIVE="$(cd "$(dirname "$ARCHIVE")" && pwd)/$(basename "$ARCHIVE")"
 
+# The build directory needs the SAME treatment, for the same reason, and
+# forgetting it is how this script first failed in anger: the caller passes a
+# path relative to the repo root, the script then cd's into $WORK, and the
+# relative path resolves against the temp directory instead. The staleness
+# check reported "build directory does not exist" on a directory that plainly
+# did, and refused the publish.
+#
+# It refused rather than skipping, which is the whole design working, but the
+# lesson is that ONE absolute-path conversion is never the whole fix -- every
+# caller-supplied path crossing that `cd` needs it.
+if [ -n "${2:-}" ]; then
+    [ -d "$2" ] || { echo "FAILED: build directory $2 does not exist -- cannot verify the archive matches the build it came from"; exit 1; }
+    BUILD_DIR_ARG="$(cd "$2" && pwd)"
+else
+    BUILD_DIR_ARG=""
+fi
+
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 tar -xJf "$ARCHIVE" -C "$WORK"
@@ -177,9 +194,8 @@ done
 # absence is a real error rather than a reason to skip. The guess-and-skip path
 # is kept only for running this script by hand against an archive fetched from
 # elsewhere, where there is no build tree to compare against.
-if [ -n "${2:-}" ]; then
-    BUILD_DIR="$2"
-    [ -d "$BUILD_DIR" ] || fail "build directory $BUILD_DIR does not exist -- cannot verify the archive matches the build it came from"
+if [ -n "$BUILD_DIR_ARG" ]; then
+    BUILD_DIR="$BUILD_DIR_ARG"
 else
     BUILD_DIR="$(dirname "$ARCHIVE")/../dx/harvest-ui/release/web/public"
     [ -d "$BUILD_DIR" ] || echo "note: no build tree at $BUILD_DIR; skipping the staleness comparison"


### PR DESCRIPTION
Follow-up to #33, which broke the publish it was meant to protect.

## Problem

The gate refused the first real publish after it landed:

```
FAILED: build directory target/dx/harvest-ui/release/web/public does not exist
        -- cannot verify the archive matches the build it came from
Error while executing command, exit code: 1
```

on a directory that plainly existed.

`compress-webapp` passes that path **relative to the repo root**. The script then `cd`s into its temp extraction directory before evaluating it, so the relative path resolved against `$WORK` instead.

The archive argument already had exactly this treatment — converted to an absolute path, with the comment *"Absolute: the checks below run from inside a temp extraction dir."* The build-directory argument, added one commit later, did not get it.

**One absolute-path conversion is never the whole fix.** Every caller-supplied path that crosses that `cd` needs it, and I converted one of two.

## What went right, and is worth keeping

The gate **failed closed** on a condition it could not evaluate. It refused the publish and stopped before `sign-webapp`, so:

- nothing was signed,
- no version counter was consumed,
- no bundle reached the network.

That is precisely the behaviour the previous commit chose deliberately over `if [ -d … ]` skipping — and the choice was vindicated within the hour, against its own author. Had it kept the silent-skip form, this bug would have disabled the staleness check permanently and quietly, and the publish would have looked completely normal.

## Testing

| case | result |
|---|---|
| relative build dir from repo root — **the case that failed** | passes |
| absolute build dir | passes |
| build dir genuinely missing | fails |
| archive stale vs build dir, via a *relative* path | fails, naming the resolved absolute path |

The last row matters: it confirms the fix did not trade a false failure for a silent skip. The message now reports the resolved location rather than a relative string that means nothing from where the script is standing.

[AI-assisted - Claude]

https://claude.ai/code/session_016JvRfeu5PyhAXMZdBWqqop
