### PR TITLE
fix(ui): install a wasm panic hook so panics say what they were

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -13,5 +13,31 @@ mod store_link;
 
 fn main() {
     dioxus::logger::initialize_default();
+
+    // Make wasm panics say what they were.
+    //
+    // Without a hook, a Rust panic compiled to wasm surfaces in the browser as
+    // a bare `Uncaught RuntimeError: unreachable` with a stack of raw wasm
+    // offsets and NO message -- the panic's own text, file and line are
+    // discarded before anything can print them. That is not a small
+    // inconvenience: it is the difference between a bug report that names its
+    // cause and one that can only be guessed at.
+    //
+    // Observed 2026-09-06: the first ghostkey a user connected panicked the UI
+    // immediately after the vault answered, and the console showed four
+    // identical `unreachable` traces and nothing else. The migration path it
+    // panicked in had never executed before -- it is wasm-only, so no test had
+    // ever run it -- which is exactly the code most likely to panic and least
+    // likely to explain itself.
+    //
+    // `initialize_default()` above sets up tracing, not a panic hook, so this
+    // is not redundant with it. Routed through `tracing::error!` rather than
+    // `console_error_panic_hook` so it needs no new dependency and lands in the
+    // same log stream as everything else the app reports.
+    #[cfg(target_arch = "wasm32")]
+    std::panic::set_hook(Box::new(|info| {
+        dioxus::logger::tracing::error!("PANIC: {info}");
+    }));
+
     dioxus::launch(components::App);
 }


### PR DESCRIPTION
## Problem

A Rust panic compiled to wasm surfaces in the browser as:

```
Uncaught RuntimeError: unreachable
    at harvest-ui_bg-....wasm:0x2d7af8
    at harvest-ui_bg-....wasm:0x2c3091
    ...
```

No message, no file, no line — just raw wasm offsets. The panic's own text is discarded before anything can print it.

Observed today: the first ghostkey a user ever connected panicked the UI immediately after the vault answered, and the console showed **four identical `unreachable` traces and nothing else**. The panic is in the identity-migration path, which is wasm-only and had therefore never executed anywhere before — exactly the code most likely to panic and least able to explain itself.

## Approach

`std::panic::set_hook` routed through `tracing::error!`.

- `dioxus::logger::initialize_default()` sets up **tracing, not a panic hook**, so this is not redundant with it.
- Routed through `tracing::error!` rather than adding `console_error_panic_hook`: no new dependency, and panics land in the same log stream as everything else the app reports.
- `#[cfg(target_arch = "wasm32")]` — native builds already print panics properly.

## What this does and does not do

It does **not** fix the panic. It makes that panic, and the next one, diagnosable — including on the very next load, which is how I intend to find the current one.

Verified it compiles for `wasm32-unknown-unknown`.

[AI-assisted - Claude]

https://claude.ai/code/session_016JvRfeu5PyhAXMZdBWqqop