### PR TITLE
fix(ghostkey): restore an already-shared identity instead of re-prompting

### DIFF
--- a/ui/src/components/app.rs
+++ b/ui/src/components/app.rs
@@ -107,20 +107,60 @@ pub fn App() -> Element {
                     }
                 }
 
-                // Step 3: Register the ghostkey delegate. We deliberately
-                // do NOT call `ListGhostKeys` on startup any more: the
-                // vault now auto-grants only the importing webapp (the
-                // Ghostkey Vault itself) on key import, so for any other
-                // webapp `ListGhostKeys` returns an empty list until the
-                // user explicitly approves a `RequestAnyAccess` prompt.
-                // The "Connect a ghostkey" button on the My Store empty
-                // state triggers that prompt; the response folds the
-                // shared key into APP_STATE.ghostkeys.
+                // Step 3: Register the ghostkey delegate, then ASK IT WHAT WE
+                // ALREADY HAVE.
+                //
+                // An earlier version deliberately skipped `ListGhostKeys` here,
+                // reasoning that the vault auto-grants only the importing
+                // webapp, so for any other webapp the list is empty until the
+                // user approves a `RequestAnyAccess` prompt. The premise is
+                // true. The conclusion does not follow, and skipping the call
+                // is what made the user re-approve on EVERY page load.
+                //
+                // Approving `RequestAnyAccess` PERSISTS a grant: the delegate
+                // calls `permissions::grant_third_party`, which saves
+                // `{ReadPublic, Sign}` for this requestor against that
+                // fingerprint. `handle_list` then returns exactly the keys the
+                // requestor holds `ReadPublic` on. The grant is keyed by
+                // `SignatureRequestor::WebApp(ContractInstanceId)`, and this
+                // app's contract id is fixed, so it survives a reload.
+                //
+                // So the list is empty only BEFORE the first approval -- when
+                // an empty answer is exactly right and the My Store empty state
+                // offers "Connect a ghostkey". Afterwards it returns the shared
+                // key with no prompt at all.
+                //
+                // `RequestAnyAccess` raises a user prompt every single time by
+                // construction; it is the wrong thing to call when you only
+                // want to know what you already have. Ask first, prompt only if
+                // the answer is empty.
                 let gk_wasm = include_bytes!("../../public/contracts/ghostkey_delegate.wasm");
                 match crate::gateway::register_delegate(gk_wasm).await {
                     Ok(key) => {
                         dioxus::logger::tracing::info!("Ghostkey delegate registered: {:?}", key);
-                        crate::gateway::APP_STATE.write().ghostkey_delegate_key = Some(key);
+                        crate::gateway::APP_STATE.write().ghostkey_delegate_key = Some(key.clone());
+
+                        // Restore any identity already shared with this app.
+                        // Failure is not user-facing: an empty or failed list
+                        // leaves the My Store empty state offering "Connect a
+                        // ghostkey", which is the same place the user would
+                        // have started anyway.
+                        match ghostkey_common::to_cbor(
+                            &ghostkey_common::GhostkeyRequest::ListGhostKeys,
+                        ) {
+                            Ok(payload) => {
+                                if let Err(e) =
+                                    crate::gateway::send_delegate_message(&key, payload).await
+                                {
+                                    dioxus::logger::tracing::warn!(
+                                        "Could not ask the vault for already-shared identities: {e}"
+                                    );
+                                }
+                            }
+                            Err(e) => dioxus::logger::tracing::error!(
+                                "Failed to encode ListGhostKeys: {e}"
+                            ),
+                        }
                     }
                     Err(e) => {
                         dioxus::logger::tracing::error!(


### PR DESCRIPTION
## Problem

Connecting a ghostkey had to be repeated on **every page load**.

The grant was never the problem — the app simply never asked whether it had one.

## Cause

Startup deliberately skipped `ListGhostKeys`, reasoning that the vault auto-grants only the importing webapp, so for any other webapp the list is empty until the user approves a `RequestAnyAccess` prompt.

**The premise is true. The conclusion — never call it — does not follow**, and it is what forced the re-approval.

Approving `RequestAnyAccess` **persists** a grant. The delegate calls `permissions::grant_third_party`, saving `{ReadPublic, Sign}` for this requestor against that fingerprint, and `handle_list` returns exactly the keys the requestor holds `ReadPublic` on:

```rust
// Only show ghostkeys the requestor has at least ReadPublic on.
if !permissions::has_scope(ctx, fp, requestor, GhostkeyScope::ReadPublic) {
    continue;
}
```

The grant is keyed by `SignatureRequestor::WebApp(ContractInstanceId)`, and this app's contract id is fixed, so it survives a reload.

So the list is empty **only before the first approval** — exactly when an empty answer is right and the My Store empty state offers "Connect a ghostkey". Afterwards it returns the shared key with no prompt.

`RequestAnyAccess` raises a prompt every time by construction. It is the wrong call when you only want to know what you already have, and it was the only call being made.

## The way this could have backfired, checked first

If `ListGhostKeys` could itself prompt, calling it at startup would mean a dialog on every load — worse than the bug being fixed. It cannot:

- `required_scope` returns `None` for it (*"filtered per-key inside the handler"*),
- it is not a disclosure request (`discloses_private_key` = false, pinned by a delegate test),
- it dispatches straight to `handle_list`, which filters and returns, with no prompt path.

A caller with no grant gets an empty list, not a dialog.

## Failure behaviour

Deliberately not user-facing. An empty or failed list leaves the same empty state offering "Connect a ghostkey" — where the user would have started anyway.

## Testing

353 tests pass, clippy clean on `wasm32-unknown-unknown`.

The behaviour that matters cannot be unit-tested here (it needs a real vault holding a real grant), so it will be verified on the live node after publish: load, approve once, reload, and confirm the second load shows the identity **without** a prompt.

[AI-assisted - Claude]

https://claude.ai/code/session_016JvRfeu5PyhAXMZdBWqqop